### PR TITLE
Add updateIntervalSeconds to get Grafana to refresh

### DIFF
--- a/cloud_dashboard.yaml
+++ b/cloud_dashboard.yaml
@@ -1,14 +1,15 @@
 apiVersion: 1
 
 providers:
- - name: 'default'
-   orgId: 1
-   folder: ''
-   folderUid: ''
-   type: file
-   allowUiUpdates: true # allows changes to be done to the dashboard via UI
-   editable: true # allows changes to be made to the provisioned dashboards
-   disableDeletion: true # stop dashboards provisioned form being deleted
-   options:
-     path: /etc/grafana/provisioning/dashboards
-     foldersFromFilesStructure: true
+  - name: "default"
+    orgId: 1
+    folder: ""
+    folderUid: ""
+    type: file
+    allowUiUpdates: true # allows changes to be done to the dashboard via UI
+    editable: true # allows changes to be made to the provisioned dashboards
+    disableDeletion: true # stop dashboards provisioned form being deleted
+    updateIntervalSeconds: 10 # how often Grafana will scan for changed dashboards
+    options:
+      path: /etc/grafana/provisioning/dashboards
+      foldersFromFilesStructure: true


### PR DESCRIPTION


### Description:

Grafana will not trigger a refresh to load a new JSON schema into the database without this field which comes from
https://grafana.com/docs/grafana/latest/administration/provisioning/#dashboards

---

### Submitter:

Have you:

* [x] Checked the latest commit runs on a Grafana instance using the aq personality `openstack_grafana`?
  
* [ ] Dashboards have clearly labelled panels, and are easy to read?


### Reviewer:

As part of reviewing this PR the changes must be tested on a Grafana instance. To do this:

* [x] Spin up a machine with the aq personality `openstack_grafana`

* [x] Open Grafana and navigate to browse dashboard

* [x] You should see the dashboards which are from this repo

* [ ] Import any dashboards that have been added or modified in this PR to Grafana.
  
Have you:

* [ ] Checked whether the panels are clear and easy to read?

