### PR TITLE
Correct personality referenced in the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,7 +23,7 @@ Examples of summary of changes:
 
 Have you:
 
-* [ ] Checked the latest commit runs on a Grafana instance using the aq personality `openstack_grafana`?
+* [ ] Checked the latest commit runs on a Grafana instance using the aq personality `openstack-grafana`?
   
 * [ ] Dashboards have clearly labelled panels, and are easy to read?
 
@@ -32,7 +32,7 @@ Have you:
 
 As part of reviewing this PR the changes must be tested on a Grafana instance. To do this:
 
-* [ ] Spin up a machine with the aq personality `openstack_grafana`
+* [ ] Spin up a machine with the aq personality `openstack-grafana`
 
 * [ ] Open Grafana and navigate to browse dashboard
 


### PR DESCRIPTION
### Description: Corrects personality name from `openstack_grafana` to `openstack-grafana` in the PR template

---

### Submitter:

Have you:

* [ ] Checked the latest commit runs on a Grafana instance using the aq personality `openstack_grafana`?
  
* [ ] Dashboards have clearly labelled panels, and are easy to read?


### Reviewer:

As part of reviewing this PR the changes must be tested on a Grafana instance. To do this:

* [ ] Spin up a machine with the aq personality `openstack_grafana`

* [ ] Open Grafana and navigate to browse dashboard

* [ ] You should see the dashboards which are from this repo

* [ ] Import any dashboards that have been added or modified in this PR to Grafana.
  
Have you:

* [ ] Checked whether the panels are clear and easy to read?

