### PR TITLE
Correct Swift Panel for OpenStack Services Graphs dashboard

### DIFF
--- a/openstack_service_graphs.json
+++ b/openstack_service_graphs.json
@@ -49,7 +49,7 @@
         "content": "# OpenStack Services: ${Instance}\n\nGraphs of service availability",
         "mode": "markdown"
       },
-      "pluginVersion": "10.0.1",
+      "pluginVersion": "10.0.2",
       "title": "OpenStack Services",
       "type": "text"
     },
@@ -1074,8 +1074,8 @@
           "measurement": "SwiftObjects-create_container_and_object_then_download_object",
           "orderByTime": "ASC",
           "policy": "autogen",
-          "query": "",
-          "rawQuery": false,
+          "query": "SELECT last(\"success\") FROM \"autogen\".\"SwiftObjects-create_container_and_object_then_download_object\" WHERE (\"instance\"::tag =~ /^$Instance$/) AND $timeFilter GROUP BY time($__interval) fill(null)",
+          "rawQuery": true,
           "refId": "A",
           "resultFormat": "time_series",
           "select": [
@@ -2197,8 +2197,8 @@
           "measurement": "Octavia-create_and_update_pools",
           "orderByTime": "ASC",
           "policy": "autogen",
-          "query": "",
-          "rawQuery": false,
+          "query": "SELECT last(\"success\") FROM \"autogen\".\"SwiftObjects-create_container_and_object_then_download_object\" WHERE (\"instance\"::tag =~ /^$Instance$/) AND $timeFilter GROUP BY time($__interval) fill(null)",
+          "rawQuery": true,
           "refId": "A",
           "resultFormat": "time_series",
           "select": [
@@ -4282,13 +4282,13 @@
     ]
   },
   "time": {
-    "from": "now-3h",
+    "from": "now-6h",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
   "title": "OpenStack Services Graphs",
   "uid": "services_graph",
-  "version": 2,
+  "version": 5,
   "weekStart": ""
 }


### PR DESCRIPTION
### Description:
One of the panels for swift was using a query to check for Octavia data by mistake. This has now been corrected.

### Additional Notes

Requires #21 to be merged first

### Submitter:

Have you:

* [x] Checked the latest commit runs on a Grafana instance using the aq personality `openstack-grafana`?
  
* [x] Dashboards have clearly labelled panels, and are easy to read?


### Reviewer:

As part of reviewing this PR the changes must be tested on a Grafana instance. To do this:

* [ ] Spin up a machine with the aq personality `openstack-grafana`

* [ ] Open Grafana and navigate to browse dashboard

* [ ] You should see the dashboards which are from this repo

* [ ] Import any dashboards that have been added or modified in this PR to Grafana.
  
Have you:

* [ ] Checked whether the panels are clear and easy to read?

