### PR TITLE
Add new dashboard for tracking VM states

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,4 @@ Current Dashboards:
 - OpenStack Hypervisor Status: Shows the Hypervisor status in Prod.
 - OpenStack Service Status: Shows the Status of services in Prod or PreProd.
 - OpenStack Service Status Breakdown: Breakdown of service statuses.
+- [DRAFT DASHBOARD] Cloud VMs Overview: Shows the states of VMs across the Cloud 

--- a/cloud_vms_overview.json
+++ b/cloud_vms_overview.json
@@ -1,0 +1,381 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 16,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "grafana"
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 7,
+        "x": 0,
+        "y": 0
+      },
+      "id": 6,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "# All VMs on Cloud\n\n- Stat Panel\n",
+        "mode": "markdown"
+      },
+      "pluginVersion": "10.0.2",
+      "title": "Total VM Count",
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "grafana"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 8,
+        "y": 0
+      },
+      "id": 8,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "# Active VMs\n\n- Stat Panel\n",
+        "mode": "markdown"
+      },
+      "pluginVersion": "10.0.2",
+      "title": "Active VMs",
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "grafana"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 12,
+        "y": 0
+      },
+      "id": 9,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "# Build State VMs\n\n- Stat Panel\n\nAmber - 20\n\nRed - 50",
+        "mode": "markdown"
+      },
+      "pluginVersion": "10.0.2",
+      "title": "Build State",
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "grafana"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 16,
+        "y": 0
+      },
+      "id": 10,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "# VMs in Error State\n\n- Stat Panel\n\nAmber - 10\nRed - 20",
+        "mode": "markdown"
+      },
+      "pluginVersion": "10.0.2",
+      "title": "Error State",
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "grafana"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 20,
+        "y": 0
+      },
+      "id": 11,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "# VMs Shutoff\n\n- Stat Panel\n\nAmber - 20\nRed - 50",
+        "mode": "markdown"
+      },
+      "pluginVersion": "10.0.2",
+      "title": "Shutoff VMs",
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "grafana"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 8,
+        "y": 5
+      },
+      "id": 12,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "# % Active VMs\n\n- Stat Panel\n",
+        "mode": "markdown"
+      },
+      "pluginVersion": "10.0.2",
+      "title": "% Active",
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "grafana"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 12,
+        "y": 5
+      },
+      "id": 13,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "# % Build VMs\n\n- Stat Panel\n",
+        "mode": "markdown"
+      },
+      "pluginVersion": "10.0.2",
+      "title": "% Build",
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "grafana"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 16,
+        "y": 5
+      },
+      "id": 14,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "# % Error\n\n- Stat Panel\n",
+        "mode": "markdown"
+      },
+      "pluginVersion": "10.0.2",
+      "title": "% Error",
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "grafana"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 20,
+        "y": 5
+      },
+      "id": 15,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "# % Shutoff\n\n- Stat Panel\n",
+        "mode": "markdown"
+      },
+      "pluginVersion": "10.0.2",
+      "title": "% Shutoff",
+      "type": "text"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 10
+      },
+      "id": 5,
+      "panels": [],
+      "title": "VM States over Time",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "grafana"
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 6,
+        "x": 0,
+        "y": 11
+      },
+      "id": 1,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "# VM states over time\nTime series plot of VMs:\n- Active\n",
+        "mode": "markdown"
+      },
+      "pluginVersion": "10.0.2",
+      "title": "Active VMs",
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "grafana"
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 6,
+        "x": 6,
+        "y": 11
+      },
+      "id": 3,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "# VM states over time\nTime series plot of VMs:\n- Build\n\n",
+        "mode": "markdown"
+      },
+      "pluginVersion": "10.0.2",
+      "title": "VMs in Build State",
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "grafana"
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 6,
+        "x": 12,
+        "y": 11
+      },
+      "id": 2,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "# VM states over time\nTime series plot of VMs:\n- Error\n",
+        "mode": "markdown"
+      },
+      "pluginVersion": "10.0.2",
+      "title": "VMs in Error State",
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "grafana"
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 6,
+        "x": 18,
+        "y": 11
+      },
+      "id": 4,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "# VM states over time\nTime series plot of VMs:\n- Shutoff\n",
+        "mode": "markdown"
+      },
+      "pluginVersion": "10.0.2",
+      "title": "VMs in Shutoff State",
+      "type": "text"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Cloud VMs Overview",
+  "uid": "cloud_vms_overview",
+  "version": 6,
+  "weekStart": ""
+}


### PR DESCRIPTION
### Description: 

- A new dashboard for monitoring VM states across the cloud. 
- Updated README to include current draft dashboard

This is a draft dashboard where panels are text panels showing the potential layout of the dashboard

![image](https://github.com/stfc/cloud-grafana-dashboards/assets/68336207/0a942d15-d477-4cb3-86b0-70c7331427ea)

### Submitter:

Have you:

* [ ] Checked the latest commit runs on a Grafana instance using the aq personality `openstack-grafana`?
  
* [ ] Dashboards have clearly labelled panels, and are easy to read?


### Reviewer:

As part of reviewing this PR the changes must be tested on a Grafana instance. To do this:

* [ ] Spin up a machine with the aq personality `openstack-grafana`

* [ ] Open Grafana and navigate to browse dashboard

* [ ] You should see the dashboards which are from this repo

* [ ] Import any dashboards that have been added or modified in this PR to Grafana.
  
Have you:

* [ ] Checked whether the panels are clear and easy to read?

