### PR TITLE
MAINT: Remove value mapping from avg availability over time on Swift

### DIFF
--- a/openstack_avg_availability_over_time.json
+++ b/openstack_avg_availability_over_time.json
@@ -24,7 +24,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 11,
+  "id": 3,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -49,7 +49,7 @@
         "content": "# ${Instance} Cloud Service - Availability for ${__url_time_range}\n",
         "mode": "markdown"
       },
-      "pluginVersion": "10.0.1",
+      "pluginVersion": "10.0.2",
       "title": "Service Availability",
       "type": "text"
     },
@@ -123,7 +123,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "10.0.1",
+      "pluginVersion": "10.0.2",
       "targets": [
         {
           "datasource": {
@@ -197,7 +197,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "10.0.1",
+      "pluginVersion": "10.0.2",
       "targets": [
         {
           "datasource": {
@@ -283,7 +283,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "10.0.1",
+      "pluginVersion": "10.0.2",
       "targets": [
         {
           "datasource": {
@@ -356,7 +356,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "10.0.1",
+      "pluginVersion": "10.0.2",
       "targets": [
         {
           "datasource": {
@@ -429,7 +429,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "10.0.1",
+      "pluginVersion": "10.0.2",
       "targets": [
         {
           "datasource": {
@@ -502,7 +502,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "10.0.1",
+      "pluginVersion": "10.0.2",
       "targets": [
         {
           "datasource": {
@@ -575,7 +575,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "10.0.1",
+      "pluginVersion": "10.0.2",
       "targets": [
         {
           "datasource": {
@@ -658,7 +658,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "10.0.1",
+      "pluginVersion": "10.0.2",
       "targets": [
         {
           "datasource": {
@@ -720,17 +720,7 @@
           "color": {
             "mode": "thresholds"
           },
-          "mappings": [
-            {
-              "options": {
-                "1": {
-                  "index": 0,
-                  "text": "True"
-                }
-              },
-              "type": "value"
-            }
-          ],
+          "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -777,7 +767,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "10.0.1",
+      "pluginVersion": "10.0.2",
       "targets": [
         {
           "datasource": {
@@ -886,7 +876,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "10.0.1",
+      "pluginVersion": "10.0.2",
       "title": "Octavia",
       "type": "stat"
     },
@@ -947,7 +937,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "10.0.1",
+      "pluginVersion": "10.0.2",
       "targets": [
         {
           "datasource": {
@@ -1009,6 +999,6 @@
   "timezone": "",
   "title": "Cloud Availability Over Time",
   "uid": "avg_cloud_availability",
-  "version": 3,
+  "version": 2,
   "weekStart": ""
 }


### PR DESCRIPTION
### Description:

This panel was showing True instead of 100 percent, removed the value mapping on the panel to be consistent with the rest of the dashboard panels

---

### Submitter:

Have you:

* [x] Checked the latest commit runs on a Grafana instance using the aq personality `openstack-grafana`?
  
* [x] Dashboards have clearly labelled panels, and are easy to read?


### Reviewer:

As part of reviewing this PR the changes must be tested on a Grafana instance. To do this:

* [x] Spin up a machine with the aq personality `openstack-grafana`

* [x] Open Grafana and navigate to browse dashboard

* [x] You should see the dashboards which are from this repo

* [ ] Import any dashboards that have been added or modified in this PR to Grafana.
  
Have you:

* [ ] Checked whether the panels are clear and easy to read?

