### PR TITLE
BUG: Add missing character to query for private VM creation panel

### DIFF
--- a/openstack_availability.json
+++ b/openstack_availability.json
@@ -224,7 +224,7 @@
             "type": "influxdb",
             "uid": "openstack_grafana"
           },
-          "query": "SELECT mean(\"success\") FROM \"VMTasks-boot_runcommand_delete\" WHERE (\"instance\" =~  /$Instance$/ AND \"network\" = 'MonitoringPrivate') AND  $timeFilter GROUP BY time($interval)",
+          "query": "SELECT mean(\"success\") FROM \"VMTasks-boot_runcommand_delete\" WHERE (\"instance\" =~  /^$Instance$/ AND \"network\" = 'MonitoringPrivate') AND  $timeFilter GROUP BY time($interval)",
           "rawQuery": true,
           "refId": "A",
           "resultFormat": "time_series"


### PR DESCRIPTION
### Description: 

There was a missing character for one panel in the current availability dashboard. This caused the panel display current availability using both prod and preprod data


---

### Submitter:

Have you:

* [x] Checked the latest commit runs on a Grafana instance using the aq personality `openstack-grafana`?
  
* [x] Dashboards have clearly labelled panels, and are easy to read?


### Reviewer:

As part of reviewing this PR the changes must be tested on a Grafana instance. To do this:

* [ ] Spin up a machine with the aq personality `openstack-grafana`

* [ ] Open Grafana and navigate to browse dashboard

* [ ] You should see the dashboards which are from this repo

* [ ] Import any dashboards that have been added or modified in this PR to Grafana.
  
Have you:

* [ ] Checked whether the panels are clear and easy to read?

