### PR TITLE
BUG: Add missing query for Octavia Panel

### DIFF
--- a/openstack_avg_availability_over_time.json
+++ b/openstack_avg_availability_over_time.json
@@ -24,7 +24,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 3,
+  "id": 7,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -49,7 +49,7 @@
         "content": "# ${Instance} Cloud Service - Availability for ${__url_time_range}\n",
         "mode": "markdown"
       },
-      "pluginVersion": "10.0.2",
+      "pluginVersion": "10.3.1",
       "title": "Service Availability",
       "type": "text"
     },
@@ -98,7 +98,8 @@
               }
             ]
           },
-          "unit": "percentunit"
+          "unit": "percentunit",
+          "unitScale": true
         },
         "overrides": []
       },
@@ -121,9 +122,11 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.0.2",
+      "pluginVersion": "10.3.1",
       "targets": [
         {
           "datasource": {
@@ -172,7 +175,8 @@
               }
             ]
           },
-          "unit": "percentunit"
+          "unit": "percentunit",
+          "unitScale": true
         },
         "overrides": []
       },
@@ -195,9 +199,11 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.0.2",
+      "pluginVersion": "10.3.1",
       "targets": [
         {
           "datasource": {
@@ -258,7 +264,8 @@
               }
             ]
           },
-          "unit": "percentunit"
+          "unit": "percentunit",
+          "unitScale": true
         },
         "overrides": []
       },
@@ -281,9 +288,11 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.0.2",
+      "pluginVersion": "10.3.1",
       "targets": [
         {
           "datasource": {
@@ -331,7 +340,8 @@
               }
             ]
           },
-          "unit": "percentunit"
+          "unit": "percentunit",
+          "unitScale": true
         },
         "overrides": []
       },
@@ -354,9 +364,11 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.0.2",
+      "pluginVersion": "10.3.1",
       "targets": [
         {
           "datasource": {
@@ -404,7 +416,8 @@
               }
             ]
           },
-          "unit": "percentunit"
+          "unit": "percentunit",
+          "unitScale": true
         },
         "overrides": []
       },
@@ -427,9 +440,11 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.0.2",
+      "pluginVersion": "10.3.1",
       "targets": [
         {
           "datasource": {
@@ -477,7 +492,8 @@
               }
             ]
           },
-          "unit": "percentunit"
+          "unit": "percentunit",
+          "unitScale": true
         },
         "overrides": []
       },
@@ -500,9 +516,11 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.0.2",
+      "pluginVersion": "10.3.1",
       "targets": [
         {
           "datasource": {
@@ -550,7 +568,8 @@
               }
             ]
           },
-          "unit": "percentunit"
+          "unit": "percentunit",
+          "unitScale": true
         },
         "overrides": []
       },
@@ -573,9 +592,11 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.0.2",
+      "pluginVersion": "10.3.1",
       "targets": [
         {
           "datasource": {
@@ -633,7 +654,8 @@
               }
             ]
           },
-          "unit": "percentunit"
+          "unit": "percentunit",
+          "unitScale": true
         },
         "overrides": []
       },
@@ -656,9 +678,11 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.0.2",
+      "pluginVersion": "10.3.1",
       "targets": [
         {
           "datasource": {
@@ -742,7 +766,8 @@
               }
             ]
           },
-          "unit": "percentunit"
+          "unit": "percentunit",
+          "unitScale": true
         },
         "overrides": []
       },
@@ -765,9 +790,11 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.0.2",
+      "pluginVersion": "10.3.1",
       "targets": [
         {
           "datasource": {
@@ -851,7 +878,8 @@
               }
             ]
           },
-          "unit": "percentunit"
+          "unit": "percentunit",
+          "unitScale": true
         },
         "overrides": []
       },
@@ -874,9 +902,59 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.0.2",
+      "pluginVersion": "10.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "openstack_grafana"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "Octavia-create_and_list_loadbalancers",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "success"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "instance",
+              "operator": "!~",
+              "value": "/^$Instance$/"
+            }
+          ]
+        }
+      ],
       "title": "Octavia",
       "type": "stat"
     },
@@ -912,7 +990,8 @@
               }
             ]
           },
-          "unit": "percentunit"
+          "unit": "percentunit",
+          "unitScale": true
         },
         "overrides": []
       },
@@ -935,9 +1014,11 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.0.2",
+      "pluginVersion": "10.3.1",
       "targets": [
         {
           "datasource": {
@@ -956,14 +1037,13 @@
   ],
   "refresh": "10s",
   "revision": 1,
-  "schemaVersion": 38,
-  "style": "dark",
+  "schemaVersion": 39,
   "tags": [],
   "templating": {
     "list": [
       {
         "current": {
-          "selected": true,
+          "selected": false,
           "text": "Prod",
           "value": "Prod"
         },
@@ -999,6 +1079,6 @@
   "timezone": "",
   "title": "Cloud Availability Over Time",
   "uid": "avg_cloud_availability",
-  "version": 2,
+  "version": 1,
   "weekStart": ""
 }


### PR DESCRIPTION
### Description:

Cloud Availability over time panel for Octavia was missing a query. The query has now been added.


### Submitter:

Have you:

* [x] Checked the latest commit runs on a Grafana instance using the aq personality `openstack-grafana`?
  
* [x] Dashboards have clearly labelled panels, and are easy to read?


### Reviewer:

As part of reviewing this PR the changes must be tested on a Grafana instance. To do this:

* [ ] Spin up a machine with the aq personality `openstack-grafana`

* [ ] Open Grafana and navigate to browse dashboard

* [ ] You should see the dashboards which are from this repo

* [ ] Import any dashboards that have been added or modified in this PR to Grafana.
  
Have you:

* [ ] Checked whether the panels are clear and easy to read?

