### PR TITLE
MAINT: Fixed dashboards showing no data

### DIFF
--- a/Power-Metrics/cloud_power_metrics.json
+++ b/Power-Metrics/cloud_power_metrics.json
@@ -18,7 +18,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 18,
+  "id": 3,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -43,7 +43,7 @@
         "content": "# Cloud Power Metrics",
         "mode": "markdown"
       },
-      "pluginVersion": "10.3.1",
+      "pluginVersion": "10.4.0",
       "targets": [
         {
           "alias": "",
@@ -106,8 +106,7 @@
               }
             ]
           },
-          "unit": "watt",
-          "unitScale": true
+          "unit": "watt"
         },
         "overrides": []
       },
@@ -134,7 +133,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "10.3.1",
+      "pluginVersion": "10.4.0",
       "targets": [
         {
           "alias": "",
@@ -188,8 +187,7 @@
                 "value": null
               }
             ]
-          },
-          "unitScale": true
+          }
         },
         "overrides": []
       },
@@ -216,7 +214,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "10.3.1",
+      "pluginVersion": "10.4.0",
       "targets": [
         {
           "alias": "",
@@ -278,8 +276,7 @@
               }
             ]
           },
-          "unit": "watt",
-          "unitScale": true
+          "unit": "watt"
         },
         "overrides": []
       },
@@ -306,7 +303,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "10.3.1",
+      "pluginVersion": "10.4.0",
       "targets": [
         {
           "alias": "",
@@ -369,8 +366,7 @@
               }
             ]
           },
-          "unit": "watt",
-          "unitScale": true
+          "unit": "watt"
         },
         "overrides": []
       },
@@ -397,7 +393,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "10.3.1",
+      "pluginVersion": "10.4.0",
       "repeat": "hosts",
       "repeatDirection": "h",
       "targets": [
@@ -471,13 +467,13 @@
     ]
   },
   "time": {
-    "from": "2023-12-01T00:00:00.000Z",
-    "to": "2023-12-01T00:01:00.000Z"
+    "from": "now-24h",
+    "to": "now"
   },
   "timepicker": {},
   "timezone": "",
   "title": "Cloud Power Metrics",
   "uid": "fe117015-9955-4352-9e15-7f21ab944f4a",
-  "version": 14,
+  "version": 1,
   "weekStart": ""
 }

--- a/Power-Metrics/cloud_rack_average_energy_usage.json
+++ b/Power-Metrics/cloud_rack_average_energy_usage.json
@@ -18,7 +18,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 12,
+  "id": 2,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -71,10 +71,12 @@
           "fields": "",
           "values": false
         },
+        "showPercentChange": false,
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.1.4",
+      "pluginVersion": "10.4.0",
       "targets": [
         {
           "alias": "",
@@ -140,7 +142,6 @@
           "timeField": "@timestamp"
         }
       ],
-      "transformations": [],
       "type": "stat"
     },
     {
@@ -193,10 +194,12 @@
           "limit": 1,
           "values": true
         },
+        "showPercentChange": false,
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.1.4",
+      "pluginVersion": "10.4.0",
       "targets": [
         {
           "alias": "",
@@ -262,7 +265,6 @@
           "timeField": "@timestamp"
         }
       ],
-      "transformations": [],
       "type": "stat"
     },
     {
@@ -314,9 +316,11 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.1.4",
+      "pluginVersion": "10.4.0",
       "targets": [
         {
           "alias": "",
@@ -381,7 +385,6 @@
           "timeField": "@timestamp"
         }
       ],
-      "transformations": [],
       "type": "stat"
     },
     {
@@ -434,10 +437,12 @@
           "limit": 1,
           "values": true
         },
+        "showPercentChange": false,
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.1.4",
+      "pluginVersion": "10.4.0",
       "targets": [
         {
           "alias": "",
@@ -503,7 +508,6 @@
           "timeField": "@timestamp"
         }
       ],
-      "transformations": [],
       "type": "stat"
     },
     {
@@ -555,9 +559,11 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.1.4",
+      "pluginVersion": "10.4.0",
       "targets": [
         {
           "alias": "",
@@ -622,7 +628,6 @@
           "timeField": "@timestamp"
         }
       ],
-      "transformations": [],
       "type": "stat"
     },
     {
@@ -675,10 +680,12 @@
           "limit": 1,
           "values": true
         },
+        "showPercentChange": false,
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.1.4",
+      "pluginVersion": "10.4.0",
       "targets": [
         {
           "alias": "",
@@ -744,7 +751,6 @@
           "timeField": "@timestamp"
         }
       ],
-      "transformations": [],
       "type": "stat"
     },
     {
@@ -796,9 +802,11 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.1.4",
+      "pluginVersion": "10.4.0",
       "targets": [
         {
           "alias": "",
@@ -863,7 +871,6 @@
           "timeField": "@timestamp"
         }
       ],
-      "transformations": [],
       "type": "stat"
     },
     {
@@ -916,10 +923,12 @@
           "limit": 1,
           "values": true
         },
+        "showPercentChange": false,
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.1.4",
+      "pluginVersion": "10.4.0",
       "targets": [
         {
           "alias": "",
@@ -985,7 +994,6 @@
           "timeField": "@timestamp"
         }
       ],
-      "transformations": [],
       "type": "stat"
     },
     {
@@ -1037,9 +1045,11 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.1.4",
+      "pluginVersion": "10.4.0",
       "targets": [
         {
           "alias": "",
@@ -1104,7 +1114,6 @@
           "timeField": "@timestamp"
         }
       ],
-      "transformations": [],
       "type": "stat"
     },
     {
@@ -1169,10 +1178,12 @@
           "limit": 1,
           "values": true
         },
+        "showPercentChange": false,
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.1.4",
+      "pluginVersion": "10.4.0",
       "targets": [
         {
           "alias": "",
@@ -1238,7 +1249,6 @@
           "timeField": "@timestamp"
         }
       ],
-      "transformations": [],
       "type": "stat"
     },
     {
@@ -1290,9 +1300,11 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.1.4",
+      "pluginVersion": "10.4.0",
       "targets": [
         {
           "alias": "",
@@ -1357,7 +1369,6 @@
           "timeField": "@timestamp"
         }
       ],
-      "transformations": [],
       "type": "stat"
     },
     {
@@ -1410,10 +1421,12 @@
           "limit": 1,
           "values": true
         },
+        "showPercentChange": false,
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.1.4",
+      "pluginVersion": "10.4.0",
       "targets": [
         {
           "alias": "",
@@ -1479,7 +1492,6 @@
           "timeField": "@timestamp"
         }
       ],
-      "transformations": [],
       "type": "stat"
     },
     {
@@ -1531,9 +1543,11 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.1.4",
+      "pluginVersion": "10.4.0",
       "targets": [
         {
           "alias": "",
@@ -1598,7 +1612,6 @@
           "timeField": "@timestamp"
         }
       ],
-      "transformations": [],
       "type": "stat"
     },
     {
@@ -1651,10 +1664,12 @@
           "limit": 1,
           "values": true
         },
+        "showPercentChange": false,
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.1.4",
+      "pluginVersion": "10.4.0",
       "targets": [
         {
           "alias": "",
@@ -1720,7 +1735,6 @@
           "timeField": "@timestamp"
         }
       ],
-      "transformations": [],
       "type": "stat"
     },
     {
@@ -1772,9 +1786,11 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.1.4",
+      "pluginVersion": "10.4.0",
       "targets": [
         {
           "alias": "",
@@ -1839,7 +1855,6 @@
           "timeField": "@timestamp"
         }
       ],
-      "transformations": [],
       "type": "stat"
     },
     {
@@ -1892,10 +1907,12 @@
           "limit": 1,
           "values": true
         },
+        "showPercentChange": false,
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.1.4",
+      "pluginVersion": "10.4.0",
       "targets": [
         {
           "alias": "",
@@ -1961,7 +1978,6 @@
           "timeField": "@timestamp"
         }
       ],
-      "transformations": [],
       "type": "stat"
     },
     {
@@ -2013,9 +2029,11 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.1.4",
+      "pluginVersion": "10.4.0",
       "targets": [
         {
           "alias": "",
@@ -2080,7 +2098,6 @@
           "timeField": "@timestamp"
         }
       ],
-      "transformations": [],
       "type": "stat"
     },
     {
@@ -2145,10 +2162,12 @@
           "limit": 1,
           "values": true
         },
+        "showPercentChange": false,
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.1.4",
+      "pluginVersion": "10.4.0",
       "targets": [
         {
           "alias": "",
@@ -2214,7 +2233,6 @@
           "timeField": "@timestamp"
         }
       ],
-      "transformations": [],
       "type": "stat"
     },
     {
@@ -2266,9 +2284,11 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.1.4",
+      "pluginVersion": "10.4.0",
       "targets": [
         {
           "alias": "",
@@ -2333,7 +2353,6 @@
           "timeField": "@timestamp"
         }
       ],
-      "transformations": [],
       "type": "stat"
     },
     {
@@ -2386,10 +2405,12 @@
           "limit": 1,
           "values": true
         },
+        "showPercentChange": false,
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.1.4",
+      "pluginVersion": "10.4.0",
       "targets": [
         {
           "alias": "",
@@ -2455,7 +2476,6 @@
           "timeField": "@timestamp"
         }
       ],
-      "transformations": [],
       "type": "stat"
     },
     {
@@ -2507,9 +2527,11 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.1.4",
+      "pluginVersion": "10.4.0",
       "targets": [
         {
           "alias": "",
@@ -2574,7 +2596,6 @@
           "timeField": "@timestamp"
         }
       ],
-      "transformations": [],
       "type": "stat"
     },
     {
@@ -2627,10 +2648,12 @@
           "limit": 1,
           "values": true
         },
+        "showPercentChange": false,
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.1.4",
+      "pluginVersion": "10.4.0",
       "targets": [
         {
           "alias": "",
@@ -2696,7 +2719,6 @@
           "timeField": "@timestamp"
         }
       ],
-      "transformations": [],
       "type": "stat"
     },
     {
@@ -2748,9 +2770,11 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.1.4",
+      "pluginVersion": "10.4.0",
       "targets": [
         {
           "alias": "",
@@ -2815,7 +2839,6 @@
           "timeField": "@timestamp"
         }
       ],
-      "transformations": [],
       "type": "stat"
     },
     {
@@ -2868,10 +2891,12 @@
           "limit": 1,
           "values": true
         },
+        "showPercentChange": false,
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.1.4",
+      "pluginVersion": "10.4.0",
       "targets": [
         {
           "alias": "",
@@ -2937,7 +2962,6 @@
           "timeField": "@timestamp"
         }
       ],
-      "transformations": [],
       "type": "stat"
     },
     {
@@ -2989,9 +3013,11 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.1.4",
+      "pluginVersion": "10.4.0",
       "targets": [
         {
           "alias": "",
@@ -3056,7 +3082,6 @@
           "timeField": "@timestamp"
         }
       ],
-      "transformations": [],
       "type": "stat"
     },
     {
@@ -3121,10 +3146,12 @@
           "limit": 1,
           "values": true
         },
+        "showPercentChange": false,
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.1.4",
+      "pluginVersion": "10.4.0",
       "targets": [
         {
           "alias": "",
@@ -3190,7 +3217,6 @@
           "timeField": "@timestamp"
         }
       ],
-      "transformations": [],
       "type": "stat"
     },
     {
@@ -3242,9 +3268,11 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.1.4",
+      "pluginVersion": "10.4.0",
       "targets": [
         {
           "alias": "",
@@ -3309,7 +3337,6 @@
           "timeField": "@timestamp"
         }
       ],
-      "transformations": [],
       "type": "stat"
     },
     {
@@ -3362,10 +3389,12 @@
           "limit": 1,
           "values": true
         },
+        "showPercentChange": false,
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.1.4",
+      "pluginVersion": "10.4.0",
       "targets": [
         {
           "alias": "",
@@ -3431,7 +3460,6 @@
           "timeField": "@timestamp"
         }
       ],
-      "transformations": [],
       "type": "stat"
     },
     {
@@ -3483,9 +3511,11 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.1.4",
+      "pluginVersion": "10.4.0",
       "targets": [
         {
           "alias": "",
@@ -3550,7 +3580,6 @@
           "timeField": "@timestamp"
         }
       ],
-      "transformations": [],
       "type": "stat"
     },
     {
@@ -3603,10 +3632,12 @@
           "limit": 1,
           "values": true
         },
+        "showPercentChange": false,
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.1.4",
+      "pluginVersion": "10.4.0",
       "targets": [
         {
           "alias": "",
@@ -3672,7 +3703,6 @@
           "timeField": "@timestamp"
         }
       ],
-      "transformations": [],
       "type": "stat"
     },
     {
@@ -3724,9 +3754,11 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.1.4",
+      "pluginVersion": "10.4.0",
       "targets": [
         {
           "alias": "",
@@ -3791,7 +3823,6 @@
           "timeField": "@timestamp"
         }
       ],
-      "transformations": [],
       "type": "stat"
     },
     {
@@ -3844,10 +3875,12 @@
           "limit": 1,
           "values": true
         },
+        "showPercentChange": false,
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.1.4",
+      "pluginVersion": "10.4.0",
       "targets": [
         {
           "alias": "",
@@ -3913,7 +3946,6 @@
           "timeField": "@timestamp"
         }
       ],
-      "transformations": [],
       "type": "stat"
     },
     {
@@ -3965,9 +3997,11 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.1.4",
+      "pluginVersion": "10.4.0",
       "targets": [
         {
           "alias": "",
@@ -4032,7 +4066,6 @@
           "timeField": "@timestamp"
         }
       ],
-      "transformations": [],
       "type": "stat"
     },
     {
@@ -4097,10 +4130,12 @@
           "limit": 1,
           "values": true
         },
+        "showPercentChange": false,
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.1.4",
+      "pluginVersion": "10.4.0",
       "targets": [
         {
           "alias": "",
@@ -4166,7 +4201,6 @@
           "timeField": "@timestamp"
         }
       ],
-      "transformations": [],
       "type": "stat"
     },
     {
@@ -4218,9 +4252,11 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.1.4",
+      "pluginVersion": "10.4.0",
       "targets": [
         {
           "alias": "",
@@ -4285,7 +4321,6 @@
           "timeField": "@timestamp"
         }
       ],
-      "transformations": [],
       "type": "stat"
     },
     {
@@ -4338,10 +4373,12 @@
           "limit": 1,
           "values": true
         },
+        "showPercentChange": false,
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.1.4",
+      "pluginVersion": "10.4.0",
       "targets": [
         {
           "alias": "",
@@ -4407,7 +4444,6 @@
           "timeField": "@timestamp"
         }
       ],
-      "transformations": [],
       "type": "stat"
     },
     {
@@ -4459,9 +4495,11 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.1.4",
+      "pluginVersion": "10.4.0",
       "targets": [
         {
           "alias": "",
@@ -4526,7 +4564,6 @@
           "timeField": "@timestamp"
         }
       ],
-      "transformations": [],
       "type": "stat"
     },
     {
@@ -4579,10 +4616,12 @@
           "limit": 1,
           "values": true
         },
+        "showPercentChange": false,
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.1.4",
+      "pluginVersion": "10.4.0",
       "targets": [
         {
           "alias": "",
@@ -4648,7 +4687,6 @@
           "timeField": "@timestamp"
         }
       ],
-      "transformations": [],
       "type": "stat"
     },
     {
@@ -4700,9 +4738,11 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.1.4",
+      "pluginVersion": "10.4.0",
       "targets": [
         {
           "alias": "",
@@ -4767,7 +4807,6 @@
           "timeField": "@timestamp"
         }
       ],
-      "transformations": [],
       "type": "stat"
     },
     {
@@ -4820,10 +4859,12 @@
           "limit": 1,
           "values": true
         },
+        "showPercentChange": false,
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.1.4",
+      "pluginVersion": "10.4.0",
       "targets": [
         {
           "alias": "",
@@ -4889,7 +4930,6 @@
           "timeField": "@timestamp"
         }
       ],
-      "transformations": [],
       "type": "stat"
     },
     {
@@ -4941,9 +4981,11 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.1.4",
+      "pluginVersion": "10.4.0",
       "targets": [
         {
           "alias": "",
@@ -5008,7 +5050,6 @@
           "timeField": "@timestamp"
         }
       ],
-      "transformations": [],
       "type": "stat"
     },
     {
@@ -5073,10 +5114,12 @@
           "limit": 1,
           "values": true
         },
+        "showPercentChange": false,
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.1.4",
+      "pluginVersion": "10.4.0",
       "targets": [
         {
           "alias": "",
@@ -5142,7 +5185,6 @@
           "timeField": "@timestamp"
         }
       ],
-      "transformations": [],
       "type": "stat"
     },
     {
@@ -5157,6 +5199,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -5289,13 +5332,11 @@
           "timeField": "@timestamp"
         }
       ],
-      "transformations": [],
       "type": "timeseries"
     }
   ],
   "refresh": false,
-  "schemaVersion": 38,
-  "style": "dark",
+  "schemaVersion": 39,
   "tags": [],
   "templating": {
     "list": []
@@ -5308,6 +5349,6 @@
   "timezone": "",
   "title": "Cloud Rack Average Energy Usage",
   "uid": "cloud_rack_average_energy_usage",
-  "version": 47,
+  "version": 2,
   "weekStart": ""
 }


### PR DESCRIPTION
The dashboards had been saved looking at a specific date in the past where there is no data. I have changed this such that the dashboards look at the past 24 hours by default.

### Description:

<!--
This should be a brief description of the PR. Details should be contained in commit messages

The PR should be restricted to only two or three changes. For adding new dashboards this should be done over more than one PR due to the size of the JSON files for dashboards.

Examples of summary of changes:
- Which dashboards were updated
- If new dashboards were created, a summary of what the dashboards will show

-->

### Additional Notes

<!-- This section can be removed if not required 

-->

---

### Submitter:

Have you:

* [x] Checked the latest commit runs on a Grafana instance using the aq personality `openstack-grafana`?
  
* [x] Dashboards have clearly labelled panels, and are easy to read?


### Reviewer:

As part of reviewing this PR the changes must be tested on a Grafana instance. To do this:

* [ ] Spin up a machine with the aq personality `openstack-grafana`

* [ ] In `/etc/grafana/grafana.ini` under `[server]` comment out: domain, root_url, http_addr. Restart Grafana

* [ ] As Root change the git branch the dashboard folder (`/etc/grafana/provisioning/dashboards`) using: `git switch <branch-name>`
  
* [ ] Restart the Grafana service: `systemctl restart grafana-server`

Have you:

* [ ] Checked whether the panels are clear and easy to read?

