### PR TITLE
Adding meerkat dasboards

### DIFF
--- a/Meerkat/cpu.json
+++ b/Meerkat/cpu.json
@@ -44,7 +44,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "ee4b2fvtkitxcc"
+          "uid": "meerkat-db"
         },
         "fieldConfig": {
           "defaults": {
@@ -100,7 +100,7 @@
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "ee4b2fvtkitxcc"
+              "uid": "meerkat-db"
             },
             "editorMode": "code",
             "expr": "avg by(flavor) (cpu_rust_result{test_type=\"$test_type\"})",
@@ -146,7 +146,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "ee4b2fvtkitxcc"
+          "uid": "meerkat-db"
         },
         "fieldConfig": {
           "defaults": {
@@ -228,7 +228,7 @@
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "ee4b2fvtkitxcc"
+              "uid": "meerkat-db"
             },
             "disableTextWrap": false,
             "editorMode": "code",
@@ -248,7 +248,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "ee4b2fvtkitxcc"
+          "uid": "meerkat-db"
         },
         "fieldConfig": {
           "defaults": {
@@ -330,7 +330,7 @@
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "ee4b2fvtkitxcc"
+              "uid": "meerkat-db"
             },
             "disableTextWrap": false,
             "editorMode": "builder",
@@ -350,7 +350,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "ee4b2fvtkitxcc"
+          "uid": "meerkat-db"
         },
         "fieldConfig": {
           "defaults": {
@@ -432,7 +432,7 @@
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "ee4b2fvtkitxcc"
+              "uid": "meerkat-db"
             },
             "disableTextWrap": false,
             "editorMode": "builder",
@@ -452,7 +452,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "ee4b2fvtkitxcc"
+          "uid": "meerkat-db"
         },
         "fieldConfig": {
           "defaults": {
@@ -534,7 +534,7 @@
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "ee4b2fvtkitxcc"
+              "uid": "meerkat-db"
             },
             "disableTextWrap": false,
             "editorMode": "builder",
@@ -567,7 +567,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "ee4b2fvtkitxcc"
+          "uid": "meerkat-db"
         },
         "fieldConfig": {
           "defaults": {
@@ -622,7 +622,7 @@
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "ee4b2fvtkitxcc"
+              "uid": "meerkat-db"
             },
             "editorMode": "code",
             "expr": "avg by(flavor) (hepscore_run_time)",
@@ -653,7 +653,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "ee4b2fvtkitxcc"
+          "uid": "meerkat-db"
         },
         "fieldConfig": {
           "defaults": {
@@ -708,7 +708,7 @@
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "ee4b2fvtkitxcc"
+              "uid": "meerkat-db"
             },
             "editorMode": "code",
             "expr": "avg by(flavor) (hepscore_score)",
@@ -739,7 +739,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "ee4b2fvtkitxcc"
+          "uid": "meerkat-db"
         },
         "fieldConfig": {
           "defaults": {
@@ -820,7 +820,7 @@
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "ee4b2fvtkitxcc"
+              "uid": "meerkat-db"
             },
             "disableTextWrap": false,
             "editorMode": "code",
@@ -840,7 +840,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "ee4b2fvtkitxcc"
+          "uid": "meerkat-db"
         },
         "fieldConfig": {
           "defaults": {
@@ -920,7 +920,7 @@
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "ee4b2fvtkitxcc"
+              "uid": "meerkat-db"
             },
             "disableTextWrap": false,
             "editorMode": "code",

--- a/Meerkat/cpu.json
+++ b/Meerkat/cpu.json
@@ -1,0 +1,1142 @@
+{
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": {
+            "type": "grafana",
+            "uid": "-- Grafana --"
+          },
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "target": {
+            "limit": 100,
+            "matchAny": false,
+            "tags": [],
+            "type": "dashboard"
+          },
+          "type": "dashboard"
+        }
+      ]
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "id": 24,
+    "links": [],
+    "liveNow": false,
+    "panels": [
+      {
+        "collapsed": false,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 0
+        },
+        "id": 7,
+        "panels": [],
+        "title": "Lightweight Rust CPU benchmarks",
+        "type": "row"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "ee4b2fvtkitxcc"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "none"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 24,
+          "x": 0,
+          "y": 1
+        },
+        "id": 6,
+        "options": {
+          "displayMode": "basic",
+          "maxVizHeight": 300,
+          "minVizHeight": 16,
+          "minVizWidth": 8,
+          "namePlacement": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "showUnfilled": true,
+          "sizing": "auto",
+          "valueMode": "text"
+        },
+        "pluginVersion": "9.2.10",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "ee4b2fvtkitxcc"
+            },
+            "editorMode": "code",
+            "expr": "avg by(flavor) (cpu_rust_result{test_type=\"$test_type\"})",
+            "instant": false,
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Average score by flavor",
+        "transformations": [
+          {
+            "id": "filterFieldsByName",
+            "options": {
+              "include": {
+                "names": [
+                  "Time",
+                  "l3.medium",
+                  "l3.micro",
+                  "l3.nano",
+                  "l3.small",
+                  "l3.tiny",
+                  "l3.xsmall",
+                  "l5.c16",
+                  "l5.c2",
+                  "l5.c32",
+                  "l5.c4",
+                  "l5.c64",
+                  "l5.c8",
+                  "l6.c16",
+                  "l6.c2",
+                  "l6.c32",
+                  "l6.c4",
+                  "l6.c64",
+                  "l6.c8"
+                ]
+              }
+            }
+          }
+        ],
+        "type": "bargauge"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "ee4b2fvtkitxcc"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "Number of iterations",
+              "axisPlacement": "auto",
+              "axisSoftMin": 0,
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "none"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 13,
+          "w": 12,
+          "x": 0,
+          "y": 9
+        },
+        "id": 2,
+        "options": {
+          "legend": {
+            "calcs": [
+              "mean",
+              "stdDev"
+            ],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "ee4b2fvtkitxcc"
+            },
+            "disableTextWrap": false,
+            "editorMode": "code",
+            "expr": "cpu_rust_result{image=~\"$Image\", flavor=~\"$Flavor\", test_type=\"primes_single\"}",
+            "fullMetaSearch": false,
+            "includeNullMetadata": true,
+            "instant": false,
+            "legendFormat": "{{image}} | {{flavor}}",
+            "range": true,
+            "refId": "A",
+            "useBackend": false
+          }
+        ],
+        "title": "prime single core",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "ee4b2fvtkitxcc"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "Number of iterations",
+              "axisPlacement": "auto",
+              "axisSoftMin": 0,
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "none"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 13,
+          "w": 12,
+          "x": 12,
+          "y": 9
+        },
+        "id": 5,
+        "options": {
+          "legend": {
+            "calcs": [
+              "mean",
+              "stdDev"
+            ],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "ee4b2fvtkitxcc"
+            },
+            "disableTextWrap": false,
+            "editorMode": "builder",
+            "expr": "cpu_rust_result{image=~\"$Image\", flavor=~\"$Flavor\", test_type=\"fft_single\"}",
+            "fullMetaSearch": false,
+            "includeNullMetadata": true,
+            "instant": false,
+            "legendFormat": "{{image}} | {{flavor}}",
+            "range": true,
+            "refId": "A",
+            "useBackend": false
+          }
+        ],
+        "title": "fft single core",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "ee4b2fvtkitxcc"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "Number of iterations",
+              "axisPlacement": "auto",
+              "axisSoftMin": 0,
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "none"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 14,
+          "w": 12,
+          "x": 0,
+          "y": 22
+        },
+        "id": 4,
+        "options": {
+          "legend": {
+            "calcs": [
+              "mean",
+              "stdDev"
+            ],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "ee4b2fvtkitxcc"
+            },
+            "disableTextWrap": false,
+            "editorMode": "builder",
+            "expr": "cpu_rust_result{image=~\"$Image\", flavor=~\"$Flavor\", test_type=\"primes_multi\"}",
+            "fullMetaSearch": false,
+            "includeNullMetadata": true,
+            "instant": false,
+            "legendFormat": "{{image}} | {{flavor}}",
+            "range": true,
+            "refId": "A",
+            "useBackend": false
+          }
+        ],
+        "title": "prime multiore",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "ee4b2fvtkitxcc"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "Number of iterations",
+              "axisPlacement": "auto",
+              "axisSoftMin": 3,
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "none"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 14,
+          "w": 12,
+          "x": 12,
+          "y": 22
+        },
+        "id": 3,
+        "options": {
+          "legend": {
+            "calcs": [
+              "mean",
+              "stdDev"
+            ],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "ee4b2fvtkitxcc"
+            },
+            "disableTextWrap": false,
+            "editorMode": "builder",
+            "expr": "cpu_rust_result{image=~\"$Image\", flavor=~\"$Flavor\", test_type=\"fft_multi\"}",
+            "fullMetaSearch": false,
+            "includeNullMetadata": true,
+            "instant": false,
+            "legendFormat": "{{image}} | {{flavor}}",
+            "range": true,
+            "refId": "A",
+            "useBackend": false
+          }
+        ],
+        "title": "fft multicore",
+        "type": "timeseries"
+      },
+      {
+        "collapsed": false,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 36
+        },
+        "id": 8,
+        "panels": [],
+        "title": "HEPScore",
+        "type": "row"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "ee4b2fvtkitxcc"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 24,
+          "x": 0,
+          "y": 37
+        },
+        "id": 10,
+        "options": {
+          "displayMode": "basic",
+          "maxVizHeight": 300,
+          "minVizHeight": 16,
+          "minVizWidth": 8,
+          "namePlacement": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "showUnfilled": true,
+          "sizing": "auto",
+          "valueMode": "text"
+        },
+        "pluginVersion": "9.2.10",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "ee4b2fvtkitxcc"
+            },
+            "editorMode": "code",
+            "expr": "avg by(flavor) (hepscore_run_time)",
+            "instant": false,
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Average runtime by flavor",
+        "transformations": [
+          {
+            "id": "filterFieldsByName",
+            "options": {
+              "include": {
+                "names": [
+                  "Time",
+                  "l3.small",
+                  "l5.c32",
+                  "l6.c32"
+                ]
+              }
+            }
+          }
+        ],
+        "type": "bargauge"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "ee4b2fvtkitxcc"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "none"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 24,
+          "x": 0,
+          "y": 45
+        },
+        "id": 11,
+        "options": {
+          "displayMode": "basic",
+          "maxVizHeight": 300,
+          "minVizHeight": 16,
+          "minVizWidth": 8,
+          "namePlacement": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "showUnfilled": true,
+          "sizing": "auto",
+          "valueMode": "text"
+        },
+        "pluginVersion": "9.2.10",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "ee4b2fvtkitxcc"
+            },
+            "editorMode": "code",
+            "expr": "avg by(flavor) (hepscore_score)",
+            "instant": false,
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Average HEPScore by flavor",
+        "transformations": [
+          {
+            "id": "filterFieldsByName",
+            "options": {
+              "include": {
+                "names": [
+                  "Time",
+                  "l3.small",
+                  "l5.c32",
+                  "l6.c32"
+                ]
+              }
+            }
+          }
+        ],
+        "type": "bargauge"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "ee4b2fvtkitxcc"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 9,
+          "w": 24,
+          "x": 0,
+          "y": 53
+        },
+        "id": 1,
+        "options": {
+          "legend": {
+            "calcs": [
+              "mean",
+              "stdDev",
+              "min"
+            ],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "ee4b2fvtkitxcc"
+            },
+            "disableTextWrap": false,
+            "editorMode": "code",
+            "expr": "hepscore_run_time{flavor=~\"$Flavor\"}",
+            "fullMetaSearch": false,
+            "includeNullMetadata": true,
+            "instant": false,
+            "legendFormat": "{{flavor}}",
+            "range": true,
+            "refId": "A",
+            "useBackend": false
+          }
+        ],
+        "title": "HEPScore - Run time",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "ee4b2fvtkitxcc"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 9,
+          "w": 24,
+          "x": 0,
+          "y": 62
+        },
+        "id": 9,
+        "options": {
+          "legend": {
+            "calcs": [
+              "mean",
+              "stdDev",
+              "min"
+            ],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "ee4b2fvtkitxcc"
+            },
+            "disableTextWrap": false,
+            "editorMode": "code",
+            "expr": "hepscore_score{flavor=~\"$Flavor\"}",
+            "fullMetaSearch": false,
+            "includeNullMetadata": true,
+            "instant": false,
+            "legendFormat": "{{flavor}}",
+            "range": true,
+            "refId": "A",
+            "useBackend": false
+          }
+        ],
+        "title": "HEPScore - Score",
+        "type": "timeseries"
+      }
+    ],
+    "refresh": "",
+    "schemaVersion": 37,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+      "list": [
+        {
+          "current": {
+            "selected": false,
+            "text": "ubuntu-focal-20.04-nogui",
+            "value": "ubuntu-focal-20.04-nogui"
+          },
+          "hide": 0,
+          "includeAll": false,
+          "label": "Image",
+          "multi": true,
+          "name": "Image",
+          "options": [
+            {
+              "selected": true,
+              "text": "ubuntu-focal-20.04-nogui",
+              "value": "ubuntu-focal-20.04-nogui"
+            },
+            {
+              "selected": false,
+              "text": "rocky-8-nogui",
+              "value": "rocky-8-nogui"
+            }
+          ],
+          "query": "ubuntu-focal-20.04-nogui, rocky-8-nogui, ubuntu-focal-20.04-gui, rocky-9-nogui",
+          "queryValue": "",
+          "skipUrlSync": false,
+          "type": "custom"
+        },
+        {
+          "current": {
+            "selected": true,
+            "text": [
+              "l3.micro"
+            ],
+            "value": [
+              "l3.micro"
+            ]
+          },
+          "hide": 0,
+          "includeAll": false,
+          "label": "Flavor",
+          "multi": true,
+          "name": "Flavor",
+          "options": [
+            {
+              "selected": false,
+              "text": "l6.c2",
+              "value": "l6.c2"
+            },
+            {
+              "selected": false,
+              "text": "l6.c4",
+              "value": "l6.c4"
+            },
+            {
+              "selected": false,
+              "text": "l6.c8",
+              "value": "l6.c8"
+            },
+            {
+              "selected": false,
+              "text": "l6.c16",
+              "value": "l6.c16"
+            },
+            {
+              "selected": false,
+              "text": "l6.c32",
+              "value": "l6.c32"
+            },
+            {
+              "selected": false,
+              "text": "l6.c64",
+              "value": "l6.c64"
+            },
+            {
+              "selected": false,
+              "text": "l6.124",
+              "value": "l6.124"
+            },
+            {
+              "selected": false,
+              "text": "l3.nano",
+              "value": "l3.nano"
+            },
+            {
+              "selected": true,
+              "text": "l3.micro",
+              "value": "l3.micro"
+            },
+            {
+              "selected": false,
+              "text": "l3.tiny",
+              "value": "l3.tiny"
+            },
+            {
+              "selected": false,
+              "text": "l3.xsmall",
+              "value": "l3.xsmall"
+            },
+            {
+              "selected": false,
+              "text": "l3.small",
+              "value": "l3.small"
+            },
+            {
+              "selected": false,
+              "text": "l5.c2",
+              "value": "l5.c2"
+            },
+            {
+              "selected": false,
+              "text": "l5.c4",
+              "value": "l5.c4"
+            },
+            {
+              "selected": false,
+              "text": "l5.c8",
+              "value": "l5.c8"
+            },
+            {
+              "selected": false,
+              "text": "l5.c16",
+              "value": "l5.c16"
+            },
+            {
+              "selected": false,
+              "text": "l5.c32",
+              "value": "l5.c32"
+            },
+            {
+              "selected": false,
+              "text": "l5.c64",
+              "value": "l5.c64"
+            },
+            {
+              "selected": false,
+              "text": "l5.c124",
+              "value": "l5.c124"
+            }
+          ],
+          "query": "l6.c2, l6.c4, l6.c8, l6.c16, l6.c32, l6.c64, l6.124, l3.nano, l3.micro, l3.tiny, l3.xsmall, l3.small, l5.c2, l5.c4, l5.c8, l5.c16, l5.c32, l5.c64, l5.c124",
+          "queryValue": "",
+          "skipUrlSync": false,
+          "type": "custom"
+        },
+        {
+          "current": {
+            "selected": false,
+            "text": "primes_single",
+            "value": "primes_single"
+          },
+          "hide": 0,
+          "includeAll": false,
+          "label": "test type",
+          "multi": false,
+          "name": "test_type",
+          "options": [
+            {
+              "selected": true,
+              "text": "primes_single",
+              "value": "primes_single"
+            },
+            {
+              "selected": false,
+              "text": "primes_multi",
+              "value": "primes_multi"
+            },
+            {
+              "selected": false,
+              "text": "fft_single",
+              "value": "fft_single"
+            },
+            {
+              "selected": false,
+              "text": "fft_multi",
+              "value": "fft_multi"
+            }
+          ],
+          "query": "primes_single, primes_multi, fft_single, fft_multi",
+          "queryValue": "",
+          "skipUrlSync": false,
+          "type": "custom"
+        }
+      ]
+    },
+    "time": {
+      "from": "now-6h",
+      "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "browser",
+    "title": "CPU benchmarks",
+    "uid": "edu0mqzje0tmoe",
+    "version": 26,
+    "weekStart": ""
+  }

--- a/Meerkat/ram.json
+++ b/Meerkat/ram.json
@@ -31,7 +31,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "ee4b2fvtkitxcc"
+          "uid": "meerkat-db"
         },
         "fieldConfig": {
           "defaults": {
@@ -114,7 +114,7 @@
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "ee4b2fvtkitxcc"
+              "uid": "meerkat-db"
             },
             "disableTextWrap": false,
             "editorMode": "code",
@@ -134,7 +134,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "ee4b2fvtkitxcc"
+          "uid": "meerkat-db"
         },
         "fieldConfig": {
           "defaults": {
@@ -217,7 +217,7 @@
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "ee4b2fvtkitxcc"
+              "uid": "meerkat-db"
             },
             "disableTextWrap": false,
             "editorMode": "code",
@@ -237,7 +237,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "ee4b2fvtkitxcc"
+          "uid": "meerkat-db"
         },
         "fieldConfig": {
           "defaults": {
@@ -320,7 +320,7 @@
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "ee4b2fvtkitxcc"
+              "uid": "meerkat-db"
             },
             "disableTextWrap": false,
             "editorMode": "code",
@@ -340,7 +340,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "ee4b2fvtkitxcc"
+          "uid": "meerkat-db"
         },
         "fieldConfig": {
           "defaults": {
@@ -424,7 +424,7 @@
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "ee4b2fvtkitxcc"
+              "uid": "meerkat-db"
             },
             "disableTextWrap": false,
             "editorMode": "code",

--- a/Meerkat/ram.json
+++ b/Meerkat/ram.json
@@ -1,0 +1,646 @@
+{
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": {
+            "type": "grafana",
+            "uid": "-- Grafana --"
+          },
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "target": {
+            "limit": 100,
+            "matchAny": false,
+            "tags": [],
+            "type": "dashboard"
+          },
+          "type": "dashboard"
+        }
+      ]
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "id": 25,
+    "links": [],
+    "liveNow": false,
+    "panels": [
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "ee4b2fvtkitxcc"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "MiBs"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 12,
+          "w": 24,
+          "x": 0,
+          "y": 0
+        },
+        "id": 1,
+        "options": {
+          "legend": {
+            "calcs": [
+              "mean",
+              "stdDev",
+              "min"
+            ],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "ee4b2fvtkitxcc"
+            },
+            "disableTextWrap": false,
+            "editorMode": "code",
+            "expr": "ram_read_speed{image=~\"$Image\", flavor=~\"$Flavor\", block_size=~\"$Block_size\"}",
+            "fullMetaSearch": false,
+            "includeNullMetadata": true,
+            "instant": false,
+            "legendFormat": "{{image}} | {{flavor}} | {{block_size}}",
+            "range": true,
+            "refId": "A",
+            "useBackend": false
+          }
+        ],
+        "title": "Read speed",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "ee4b2fvtkitxcc"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "MiBs"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 12,
+          "w": 24,
+          "x": 0,
+          "y": 12
+        },
+        "id": 2,
+        "options": {
+          "legend": {
+            "calcs": [
+              "mean",
+              "stdDev",
+              "min"
+            ],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "ee4b2fvtkitxcc"
+            },
+            "disableTextWrap": false,
+            "editorMode": "code",
+            "expr": "ram_write_speed{image=~\"$Image\", flavor=~\"$Flavor\", block_size=~\"$Block_size\"}",
+            "fullMetaSearch": false,
+            "includeNullMetadata": true,
+            "instant": false,
+            "legendFormat": "{{image}} | {{flavor}} | {{block_size}}",
+            "range": true,
+            "refId": "A",
+            "useBackend": false
+          }
+        ],
+        "title": "Write speed",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "ee4b2fvtkitxcc"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "ms"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 12,
+          "w": 24,
+          "x": 0,
+          "y": 24
+        },
+        "id": 4,
+        "options": {
+          "legend": {
+            "calcs": [
+              "mean",
+              "stdDev",
+              "min"
+            ],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "ee4b2fvtkitxcc"
+            },
+            "disableTextWrap": false,
+            "editorMode": "code",
+            "expr": "ram_read_latency{image=~\"$Image\", flavor=~\"$Flavor\", block_size=~\"$Block_size\"}",
+            "fullMetaSearch": false,
+            "includeNullMetadata": true,
+            "instant": false,
+            "legendFormat": "{{image}} | {{flavor}} | {{block_size}}",
+            "range": true,
+            "refId": "A",
+            "useBackend": false
+          }
+        ],
+        "title": "Read latency",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "ee4b2fvtkitxcc"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "ms"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 12,
+          "w": 24,
+          "x": 0,
+          "y": 36
+        },
+        "id": 5,
+        "options": {
+          "legend": {
+            "calcs": [
+              "mean",
+              "stdDev",
+              "min"
+            ],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "ee4b2fvtkitxcc"
+            },
+            "disableTextWrap": false,
+            "editorMode": "code",
+            "expr": "ram_write_latency{image=~\"$Image\", flavor=~\"$Flavor\", block_size=~\"$Block_size\"}",
+            "fullMetaSearch": false,
+            "includeNullMetadata": true,
+            "instant": false,
+            "legendFormat": "{{image}} | {{flavor}} | {{block_size}}",
+            "range": true,
+            "refId": "A",
+            "useBackend": false
+          }
+        ],
+        "title": "Write latency",
+        "type": "timeseries"
+      }
+    ],
+    "schemaVersion": 37,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+      "list": [
+        {
+          "current": {
+            "selected": false,
+            "text": "ubuntu-focal-20.04-nogui",
+            "value": "ubuntu-focal-20.04-nogui"
+          },
+          "hide": 0,
+          "includeAll": false,
+          "label": "Image",
+          "multi": true,
+          "name": "Image",
+          "options": [
+            {
+              "selected": true,
+              "text": "ubuntu-focal-20.04-nogui",
+              "value": "ubuntu-focal-20.04-nogui"
+            },
+            {
+              "selected": false,
+              "text": "rocky-8-nogui",
+              "value": "rocky-8-nogui"
+            },
+            {
+              "selected": false,
+              "text": "ubuntu-focal-20.04-gui",
+              "value": "ubuntu-focal-20.04-gui"
+            },
+            {
+              "selected": false,
+              "text": "rocky-9-nogui",
+              "value": "rocky-9-nogui"
+            }
+          ],
+          "query": "ubuntu-focal-20.04-nogui, rocky-8-nogui, ubuntu-focal-20.04-gui, rocky-9-nogui",
+          "queryValue": "",
+          "skipUrlSync": false,
+          "type": "custom"
+        },
+        {
+          "current": {
+            "selected": false,
+            "text": "l6.c2",
+            "value": "l6.c2"
+          },
+          "hide": 0,
+          "includeAll": false,
+          "label": "Flavor",
+          "multi": true,
+          "name": "Flavor",
+          "options": [
+            {
+              "selected": true,
+              "text": "l6.c2",
+              "value": "l6.c2"
+            },
+            {
+              "selected": false,
+              "text": "l6.c4",
+              "value": "l6.c4"
+            },
+            {
+              "selected": false,
+              "text": "l6.c8",
+              "value": "l6.c8"
+            },
+            {
+              "selected": false,
+              "text": "l6.c16",
+              "value": "l6.c16"
+            },
+            {
+              "selected": false,
+              "text": "l6.c32",
+              "value": "l6.c32"
+            },
+            {
+              "selected": false,
+              "text": "l6.c64",
+              "value": "l6.c64"
+            },
+            {
+              "selected": false,
+              "text": "l6.124",
+              "value": "l6.124"
+            },
+            {
+              "selected": false,
+              "text": "l3.nano",
+              "value": "l3.nano"
+            },
+            {
+              "selected": false,
+              "text": "l3.micro",
+              "value": "l3.micro"
+            },
+            {
+              "selected": false,
+              "text": "l3.tiny",
+              "value": "l3.tiny"
+            },
+            {
+              "selected": false,
+              "text": "l3.xsmall",
+              "value": "l3.xsmall"
+            },
+            {
+              "selected": false,
+              "text": "l3.small",
+              "value": "l3.small"
+            },
+            {
+              "selected": false,
+              "text": "l5.c2",
+              "value": "l5.c2"
+            },
+            {
+              "selected": false,
+              "text": "l5.c4",
+              "value": "l5.c4"
+            },
+            {
+              "selected": false,
+              "text": "l5.c8",
+              "value": "l5.c8"
+            },
+            {
+              "selected": false,
+              "text": "l5.c16",
+              "value": "l5.c16"
+            },
+            {
+              "selected": false,
+              "text": "l5.c32",
+              "value": "l5.c32"
+            },
+            {
+              "selected": false,
+              "text": "l5.c64",
+              "value": "l5.c64"
+            },
+            {
+              "selected": false,
+              "text": "l5.c124",
+              "value": "l5.c124"
+            }
+          ],
+          "query": "l6.c2, l6.c4, l6.c8, l6.c16, l6.c32, l6.c64, l6.124, l3.nano, l3.micro, l3.tiny, l3.xsmall, l3.small, l5.c2, l5.c4, l5.c8, l5.c16, l5.c32, l5.c64, l5.c124",
+          "queryValue": "",
+          "skipUrlSync": false,
+          "type": "custom"
+        },
+        {
+          "current": {
+            "selected": false,
+            "text": "1K",
+            "value": "1K"
+          },
+          "hide": 0,
+          "includeAll": false,
+          "label": "Block_size",
+          "multi": true,
+          "name": "Block_size",
+          "options": [
+            {
+              "selected": true,
+              "text": "1K",
+              "value": "1K"
+            },
+            {
+              "selected": false,
+              "text": "1M",
+              "value": "1M"
+            },
+            {
+              "selected": false,
+              "text": "1G",
+              "value": "1G"
+            }
+          ],
+          "query": "1K, 1M, 1G",
+          "queryValue": "",
+          "skipUrlSync": false,
+          "type": "custom"
+        }
+      ]
+    },
+    "time": {
+      "from": "now-6h",
+      "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "browser",
+    "title": "Ram benchmarking",
+    "uid": "adxdme7otatc0d",
+    "version": 10,
+    "weekStart": ""
+  }

--- a/Meerkat/storage.json
+++ b/Meerkat/storage.json
@@ -44,7 +44,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "ee4b2fvtkitxcc"
+          "uid": "meerkat-db"
         },
         "fieldConfig": {
           "defaults": {
@@ -127,7 +127,7 @@
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "ee4b2fvtkitxcc"
+              "uid": "meerkat-db"
             },
             "disableTextWrap": false,
             "editorMode": "code",
@@ -148,7 +148,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "ee4b2fvtkitxcc"
+          "uid": "meerkat-db"
         },
         "fieldConfig": {
           "defaults": {
@@ -231,7 +231,7 @@
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "ee4b2fvtkitxcc"
+              "uid": "meerkat-db"
             },
             "disableTextWrap": false,
             "editorMode": "builder",
@@ -252,7 +252,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "ee4b2fvtkitxcc"
+          "uid": "meerkat-db"
         },
         "fieldConfig": {
           "defaults": {
@@ -335,7 +335,7 @@
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "ee4b2fvtkitxcc"
+              "uid": "meerkat-db"
             },
             "disableTextWrap": false,
             "editorMode": "code",
@@ -369,7 +369,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "ee4b2fvtkitxcc"
+          "uid": "meerkat-db"
         },
         "fieldConfig": {
           "defaults": {
@@ -425,7 +425,7 @@
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "ee4b2fvtkitxcc"
+              "uid": "meerkat-db"
             },
             "disableTextWrap": false,
             "editorMode": "code",
@@ -447,7 +447,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "ee4b2fvtkitxcc"
+          "uid": "meerkat-db"
         },
         "fieldConfig": {
           "defaults": {
@@ -503,7 +503,7 @@
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "ee4b2fvtkitxcc"
+              "uid": "meerkat-db"
             },
             "disableTextWrap": false,
             "editorMode": "code",
@@ -525,7 +525,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "ee4b2fvtkitxcc"
+          "uid": "meerkat-db"
         },
         "fieldConfig": {
           "defaults": {
@@ -581,7 +581,7 @@
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "ee4b2fvtkitxcc"
+              "uid": "meerkat-db"
             },
             "disableTextWrap": false,
             "editorMode": "code",
@@ -603,7 +603,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "ee4b2fvtkitxcc"
+          "uid": "meerkat-db"
         },
         "fieldConfig": {
           "defaults": {
@@ -659,7 +659,7 @@
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "ee4b2fvtkitxcc"
+              "uid": "meerkat-db"
             },
             "disableTextWrap": false,
             "editorMode": "code",
@@ -681,7 +681,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "ee4b2fvtkitxcc"
+          "uid": "meerkat-db"
         },
         "fieldConfig": {
           "defaults": {
@@ -736,7 +736,7 @@
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "ee4b2fvtkitxcc"
+              "uid": "meerkat-db"
             },
             "disableTextWrap": false,
             "editorMode": "code",
@@ -758,7 +758,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "ee4b2fvtkitxcc"
+          "uid": "meerkat-db"
         },
         "fieldConfig": {
           "defaults": {
@@ -813,7 +813,7 @@
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "ee4b2fvtkitxcc"
+              "uid": "meerkat-db"
             },
             "disableTextWrap": false,
             "editorMode": "code",

--- a/Meerkat/storage.json
+++ b/Meerkat/storage.json
@@ -1,0 +1,999 @@
+{
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": {
+            "type": "grafana",
+            "uid": "-- Grafana --"
+          },
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "target": {
+            "limit": 100,
+            "matchAny": false,
+            "tags": [],
+            "type": "dashboard"
+          },
+          "type": "dashboard"
+        }
+      ]
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "id": 22,
+    "links": [],
+    "liveNow": false,
+    "panels": [
+      {
+        "collapsed": false,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 0
+        },
+        "id": 7,
+        "panels": [],
+        "title": "Detailed time series",
+        "type": "row"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "ee4b2fvtkitxcc"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "log": 10,
+                "type": "log"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "MBs"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 12,
+          "w": 24,
+          "x": 0,
+          "y": 1
+        },
+        "id": 1,
+        "options": {
+          "legend": {
+            "calcs": [
+              "mean",
+              "stdDev",
+              "min"
+            ],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "ee4b2fvtkitxcc"
+            },
+            "disableTextWrap": false,
+            "editorMode": "code",
+            "exemplar": false,
+            "expr": "storage_local{image=~\"$Image\", flavor=~\"$Flavor\", file_size=~\"$File_size\", test_type=~\"$test_type\"}",
+            "fullMetaSearch": false,
+            "includeNullMetadata": true,
+            "instant": false,
+            "legendFormat": "{{image}} | {{flavor}} | {{test_type}} | {{file_size}}",
+            "range": true,
+            "refId": "A",
+            "useBackend": false
+          }
+        ],
+        "title": "Local storage",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "ee4b2fvtkitxcc"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "log": 10,
+                "type": "log"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "MBs"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 12,
+          "w": 24,
+          "x": 0,
+          "y": 13
+        },
+        "id": 3,
+        "options": {
+          "legend": {
+            "calcs": [
+              "mean",
+              "stdDev",
+              "min"
+            ],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "ee4b2fvtkitxcc"
+            },
+            "disableTextWrap": false,
+            "editorMode": "builder",
+            "exemplar": false,
+            "expr": "storage_volume{image=~\"$Image\", flavor=~\"$Flavor\", file_size=~\"$File_size\", test_type=~\"$test_type\"}",
+            "fullMetaSearch": false,
+            "includeNullMetadata": true,
+            "instant": false,
+            "legendFormat": "{{image}} | {{flavor}} | {{test_type}} | {{file_size}}",
+            "range": true,
+            "refId": "A",
+            "useBackend": false
+          }
+        ],
+        "title": "Volume storage",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "ee4b2fvtkitxcc"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "log": 10,
+                "type": "log"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "MBs"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 9,
+          "w": 24,
+          "x": 0,
+          "y": 25
+        },
+        "id": 2,
+        "options": {
+          "legend": {
+            "calcs": [
+              "mean",
+              "stdDev",
+              "min"
+            ],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "ee4b2fvtkitxcc"
+            },
+            "disableTextWrap": false,
+            "editorMode": "code",
+            "exemplar": false,
+            "expr": "storage_manila{image=~\"$Image\", flavor=~\"$Flavor\", file_size=~\"$File_size\", test_type=~\"$test_type\"}",
+            "fullMetaSearch": false,
+            "includeNullMetadata": true,
+            "instant": false,
+            "legendFormat": "{{image}} | {{flavor}} | {{test_type}} | {{file_size}}",
+            "range": true,
+            "refId": "A",
+            "useBackend": false
+          }
+        ],
+        "title": "Manila",
+        "type": "timeseries"
+      },
+      {
+        "collapsed": false,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 34
+        },
+        "id": 8,
+        "panels": [],
+        "title": "Average speed",
+        "type": "row"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "ee4b2fvtkitxcc"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "fieldMinMax": false,
+            "mappings": [],
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "MBs"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 9,
+          "w": 24,
+          "x": 0,
+          "y": 35
+        },
+        "id": 9,
+        "options": {
+          "displayMode": "basic",
+          "maxVizHeight": 300,
+          "minVizHeight": 16,
+          "minVizWidth": 8,
+          "namePlacement": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "showUnfilled": true,
+          "sizing": "auto",
+          "valueMode": "text"
+        },
+        "pluginVersion": "10.4.4",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "ee4b2fvtkitxcc"
+            },
+            "disableTextWrap": false,
+            "editorMode": "code",
+            "exemplar": false,
+            "expr": "avg by(image) (storage_local{image!=\"hello\"})",
+            "format": "time_series",
+            "fullMetaSearch": false,
+            "includeNullMetadata": true,
+            "instant": false,
+            "legendFormat": "{{image}} ",
+            "range": true,
+            "refId": "A",
+            "useBackend": false
+          }
+        ],
+        "title": "Average speed local storage",
+        "type": "bargauge"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "ee4b2fvtkitxcc"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "fieldMinMax": false,
+            "mappings": [],
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "MBs"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 9,
+          "w": 24,
+          "x": 0,
+          "y": 44
+        },
+        "id": 11,
+        "options": {
+          "displayMode": "basic",
+          "maxVizHeight": 300,
+          "minVizHeight": 16,
+          "minVizWidth": 8,
+          "namePlacement": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "showUnfilled": true,
+          "sizing": "auto",
+          "valueMode": "text"
+        },
+        "pluginVersion": "10.4.4",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "ee4b2fvtkitxcc"
+            },
+            "disableTextWrap": false,
+            "editorMode": "code",
+            "exemplar": false,
+            "expr": "avg by(image) (storage_volume{image!=\"hello\"})",
+            "format": "time_series",
+            "fullMetaSearch": false,
+            "includeNullMetadata": true,
+            "instant": false,
+            "legendFormat": "{{image}} ",
+            "range": true,
+            "refId": "A",
+            "useBackend": false
+          }
+        ],
+        "title": "Average speed volume storage",
+        "type": "bargauge"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "ee4b2fvtkitxcc"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "fieldMinMax": false,
+            "mappings": [],
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "MBs"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 9,
+          "w": 24,
+          "x": 0,
+          "y": 53
+        },
+        "id": 10,
+        "options": {
+          "displayMode": "basic",
+          "maxVizHeight": 300,
+          "minVizHeight": 16,
+          "minVizWidth": 8,
+          "namePlacement": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "showUnfilled": true,
+          "sizing": "auto",
+          "valueMode": "text"
+        },
+        "pluginVersion": "10.4.4",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "ee4b2fvtkitxcc"
+            },
+            "disableTextWrap": false,
+            "editorMode": "code",
+            "exemplar": false,
+            "expr": "avg by(image) (storage_manila{image!=\"hello\"})",
+            "format": "time_series",
+            "fullMetaSearch": false,
+            "includeNullMetadata": true,
+            "instant": false,
+            "legendFormat": "{{image}} ",
+            "range": true,
+            "refId": "A",
+            "useBackend": false
+          }
+        ],
+        "title": "Average speed manila storage",
+        "type": "bargauge"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "ee4b2fvtkitxcc"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "fieldMinMax": false,
+            "mappings": [],
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "MBs"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 9,
+          "w": 24,
+          "x": 0,
+          "y": 62
+        },
+        "id": 4,
+        "options": {
+          "displayMode": "basic",
+          "maxVizHeight": 300,
+          "minVizHeight": 16,
+          "minVizWidth": 8,
+          "namePlacement": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "showUnfilled": true,
+          "sizing": "auto",
+          "valueMode": "text"
+        },
+        "pluginVersion": "10.4.4",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "ee4b2fvtkitxcc"
+            },
+            "disableTextWrap": false,
+            "editorMode": "code",
+            "exemplar": false,
+            "expr": "avg by(test_type, file_size) (storage_local{image!=\"hello\"})",
+            "format": "time_series",
+            "fullMetaSearch": false,
+            "includeNullMetadata": true,
+            "instant": false,
+            "legendFormat": "{{file_size}} | {{test_type}} ",
+            "range": true,
+            "refId": "A",
+            "useBackend": false
+          }
+        ],
+        "title": "Average speed local storage",
+        "type": "bargauge"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "ee4b2fvtkitxcc"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "MBs"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 9,
+          "w": 24,
+          "x": 0,
+          "y": 71
+        },
+        "id": 5,
+        "options": {
+          "displayMode": "basic",
+          "maxVizHeight": 300,
+          "minVizHeight": 16,
+          "minVizWidth": 8,
+          "namePlacement": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "showUnfilled": true,
+          "sizing": "auto",
+          "valueMode": "text"
+        },
+        "pluginVersion": "10.4.4",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "ee4b2fvtkitxcc"
+            },
+            "disableTextWrap": false,
+            "editorMode": "code",
+            "exemplar": false,
+            "expr": "avg by(test_type, file_size) (storage_volume{image!=\"hello\"})",
+            "format": "time_series",
+            "fullMetaSearch": false,
+            "includeNullMetadata": true,
+            "instant": false,
+            "legendFormat": "{{file_size}} | {{test_type}} ",
+            "range": true,
+            "refId": "A",
+            "useBackend": false
+          }
+        ],
+        "title": "Average speed volume storage",
+        "type": "bargauge"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "ee4b2fvtkitxcc"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "MBs"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 7,
+          "w": 24,
+          "x": 0,
+          "y": 80
+        },
+        "id": 6,
+        "options": {
+          "displayMode": "basic",
+          "maxVizHeight": 300,
+          "minVizHeight": 16,
+          "minVizWidth": 8,
+          "namePlacement": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "showUnfilled": true,
+          "sizing": "auto",
+          "valueMode": "text"
+        },
+        "pluginVersion": "10.4.4",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "ee4b2fvtkitxcc"
+            },
+            "disableTextWrap": false,
+            "editorMode": "code",
+            "exemplar": false,
+            "expr": "avg by(test_type, file_size) (storage_manila{image!=\"hello\"})",
+            "format": "time_series",
+            "fullMetaSearch": false,
+            "includeNullMetadata": true,
+            "instant": false,
+            "legendFormat": "{{file_size}} | {{test_type}} ",
+            "range": true,
+            "refId": "A",
+            "useBackend": false
+          }
+        ],
+        "title": "Average speed manila storage",
+        "type": "bargauge"
+      }
+    ],
+    "schemaVersion": 37,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+      "list": [
+        {
+          "current": {
+            "selected": false,
+            "text": "ubuntu-focal-20.04-nogui",
+            "value": "ubuntu-focal-20.04-nogui"
+          },
+          "hide": 0,
+          "includeAll": false,
+          "label": "Image",
+          "multi": true,
+          "name": "Image",
+          "options": [
+            {
+              "selected": true,
+              "text": "ubuntu-focal-20.04-nogui",
+              "value": "ubuntu-focal-20.04-nogui"
+            },
+            {
+              "selected": false,
+              "text": "rocky-8-nogui",
+              "value": "rocky-8-nogui"
+            }
+          ],
+          "query": "ubuntu-focal-20.04-nogui, ubuntu-focal-20.04-gui, rocky-8-nogui, rocky-9-nogui",
+          "queryValue": "",
+          "skipUrlSync": false,
+          "type": "custom"
+        },
+        {
+          "current": {
+            "selected": false,
+            "text": "l3.nano",
+            "value": "l3.nano"
+          },
+          "hide": 0,
+          "includeAll": false,
+          "label": "Flavor",
+          "multi": true,
+          "name": "Flavor",
+          "options": [
+            {
+              "selected": true,
+              "text": "l3.nano",
+              "value": "l3.nano"
+            },
+            {
+              "selected": false,
+              "text": "l3.micro",
+              "value": "l3.micro"
+            },
+            {
+              "selected": false,
+              "text": "l3.tiny",
+              "value": "l3.tiny"
+            },
+            {
+              "selected": false,
+              "text": "l3.xsmall",
+              "value": "l3.xsmall"
+            },
+            {
+              "selected": false,
+              "text": "l3.small",
+              "value": "l3.small"
+            }
+          ],
+          "query": "l3.nano, l3.micro, l3.tiny, l3.xsmall, l3.small, l5.c4, l5.c8, l6.c4, l6.c8",
+          "queryValue": "",
+          "skipUrlSync": false,
+          "type": "custom"
+        },
+        {
+          "current": {
+            "selected": false,
+            "text": "kb",
+            "value": "kb"
+          },
+          "hide": 0,
+          "includeAll": false,
+          "label": "File_size",
+          "multi": true,
+          "name": "File_size",
+          "options": [
+            {
+              "selected": true,
+              "text": "kb",
+              "value": "kb"
+            },
+            {
+              "selected": false,
+              "text": "mb",
+              "value": "mb"
+            },
+            {
+              "selected": false,
+              "text": "gb",
+              "value": "gb"
+            }
+          ],
+          "query": "kb, mb, gb",
+          "queryValue": "",
+          "skipUrlSync": false,
+          "type": "custom"
+        },
+        {
+          "current": {
+            "selected": false,
+            "text": [
+              "sequential_read"
+            ],
+            "value": [
+              "sequential_read"
+            ]
+          },
+          "hide": 0,
+          "includeAll": false,
+          "label": "Test type",
+          "multi": true,
+          "name": "test_type",
+          "options": [
+            {
+              "selected": false,
+              "text": "sequential_write",
+              "value": "sequential_write"
+            },
+            {
+              "selected": true,
+              "text": "sequential_read",
+              "value": "sequential_read"
+            },
+            {
+              "selected": false,
+              "text": "random_write",
+              "value": "random_write"
+            },
+            {
+              "selected": false,
+              "text": "random_read",
+              "value": "random_read"
+            }
+          ],
+          "query": "sequential_write, sequential_read, random_write, random_read",
+          "queryValue": "",
+          "skipUrlSync": false,
+          "type": "custom"
+        }
+      ]
+    },
+    "time": {
+      "from": "now-6h",
+      "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "browser",
+    "title": "Meerkat-storage",
+    "uid": "ddiibxwocoikgd",
+    "version": 27,
+    "weekStart": ""
+  }

--- a/Monitoring/Network_Monitoring.json
+++ b/Monitoring/Network_Monitoring.json
@@ -1,0 +1,813 @@
+{
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": {
+            "type": "grafana",
+            "uid": "-- Grafana --"
+          },
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "target": {
+            "limit": 100,
+            "matchAny": false,
+            "tags": [],
+            "type": "dashboard"
+          },
+          "type": "dashboard"
+        }
+      ]
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "id": 27,
+    "links": [],
+    "liveNow": false,
+    "panels": [
+      {
+        "collapsed": false,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 0
+        },
+        "id": 5,
+        "panels": [],
+        "title": "Ping",
+        "type": "row"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "ee4b2fvtkitxcc"
+        },
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "ms"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 1
+        },
+        "id": 2,
+        "options": {
+          "legend": {
+            "calcs": [
+              "mean",
+              "max",
+              "stdDev"
+            ],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "ee4b2fvtkitxcc"
+            },
+            "editorMode": "code",
+            "expr": "network_monitoring_rtt_average{host_id=~\"$host_id\"}",
+            "legendFormat": "{{target_id}}",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Round trip time average",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "ee4b2fvtkitxcc"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "percent"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 1
+        },
+        "id": 7,
+        "options": {
+          "legend": {
+            "calcs": [
+              "mean",
+              "max",
+              "stdDev"
+            ],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "ee4b2fvtkitxcc"
+            },
+            "editorMode": "code",
+            "expr": "network_monitoring_rtt_packet_loss{host_id=~\"$host_id\"}",
+            "legendFormat": "{{target_id}}",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Packet Loss",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "ee4b2fvtkitxcc"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "ms"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 9
+        },
+        "id": 3,
+        "options": {
+          "legend": {
+            "calcs": [
+              "mean",
+              "max",
+              "stdDev"
+            ],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "ee4b2fvtkitxcc"
+            },
+            "editorMode": "code",
+            "expr": "network_monitoring_rtt_max{host_id=~\"$host_id\"}",
+            "legendFormat": "{{target_id}}",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Round trip time max",
+        "type": "timeseries"
+      },
+      {
+        "collapsed": false,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 17
+        },
+        "id": 9,
+        "panels": [],
+        "title": "TCP",
+        "type": "row"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "ee4b2fvtkitxcc"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "Mbits"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 18
+        },
+        "id": 11,
+        "options": {
+          "legend": {
+            "calcs": [
+              "mean",
+              "min",
+              "stdDev"
+            ],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "ee4b2fvtkitxcc"
+            },
+            "editorMode": "code",
+            "expr": "network_monitoring_tcp_throughput{host_id=~\"$host_id\"}",
+            "legendFormat": "{{target_id}}",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "TCP Throughput",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "ee4b2fvtkitxcc"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "none"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 18
+        },
+        "id": 20,
+        "options": {
+          "legend": {
+            "calcs": [
+              "mean",
+              "min",
+              "stdDev"
+            ],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "ee4b2fvtkitxcc"
+            },
+            "editorMode": "code",
+            "expr": "network_monitoring_tcp_retries{host_id=~\"$host_id\"}",
+            "legendFormat": "{{target_id}}",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "TCP Retires",
+        "type": "timeseries"
+      },
+      {
+        "collapsed": false,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 26
+        },
+        "id": 17,
+        "panels": [],
+        "title": "UDP",
+        "type": "row"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "ee4b2fvtkitxcc"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "Gbits"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 27
+        },
+        "id": 15,
+        "options": {
+          "legend": {
+            "calcs": [
+              "mean",
+              "min",
+              "stdDev"
+            ],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "ee4b2fvtkitxcc"
+            },
+            "editorMode": "code",
+            "expr": "network_monitoring_udp_throughput{host_id=~\"$host_id\"}",
+            "legendFormat": "{{target_id}}",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "UDP Throughput",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "ee4b2fvtkitxcc"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "percent"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 27
+        },
+        "id": 19,
+        "options": {
+          "legend": {
+            "calcs": [
+              "mean",
+              "max",
+              "stdDev"
+            ],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "ee4b2fvtkitxcc"
+            },
+            "editorMode": "code",
+            "expr": "network_monitoring_udp_packet_loss{host_id=~\"$host_id\"}",
+            "legendFormat": "{{target_id}}",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "UDP packet loss",
+        "type": "timeseries"
+      }
+    ],
+    "refresh": false,
+    "schemaVersion": 37,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+      "list": [
+        {
+          "current": {
+            "selected": true,
+            "text": "R89",
+            "value": "R89"
+          },
+          "description": "Node id",
+          "hide": 0,
+          "includeAll": false,
+          "label": "host",
+          "multi": false,
+          "name": "host_id",
+          "options": [
+            {
+              "selected": true,
+              "text": "R89",
+              "value": "R89"
+            },
+            {
+              "selected": false,
+              "text": "R26",
+              "value": "R26"
+            },
+            {
+              "selected": false,
+              "text": "pnet",
+              "value": "pnet"
+            },
+            {
+              "selected": false,
+              "text": "FIP",
+              "value": "FIP"
+            },
+            {
+              "selected": false,
+              "text": "LB",
+              "value": "LB"
+            }
+          ],
+          "query": "R89, R26, pnet, FIP, LB",
+          "queryValue": "",
+          "skipUrlSync": false,
+          "type": "custom"
+        }
+      ]
+    },
+    "time": {
+      "from": "now-6h",
+      "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "",
+    "title": "monitoring",
+    "uid": "eIrcFCFHz",
+    "version": 21,
+    "weekStart": ""
+  }

--- a/Monitoring/Network_Monitoring.json
+++ b/Monitoring/Network_Monitoring.json
@@ -44,7 +44,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "ee4b2fvtkitxcc"
+          "uid": "meerkat-db"
         },
         "description": "",
         "fieldConfig": {
@@ -127,7 +127,7 @@
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "ee4b2fvtkitxcc"
+              "uid": "meerkat-db"
             },
             "editorMode": "code",
             "expr": "network_monitoring_rtt_average{host_id=~\"$host_id\"}",
@@ -142,7 +142,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "ee4b2fvtkitxcc"
+          "uid": "meerkat-db"
         },
         "fieldConfig": {
           "defaults": {
@@ -224,7 +224,7 @@
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "ee4b2fvtkitxcc"
+              "uid": "meerkat-db"
             },
             "editorMode": "code",
             "expr": "network_monitoring_rtt_packet_loss{host_id=~\"$host_id\"}",
@@ -239,7 +239,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "ee4b2fvtkitxcc"
+          "uid": "meerkat-db"
         },
         "fieldConfig": {
           "defaults": {
@@ -321,7 +321,7 @@
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "ee4b2fvtkitxcc"
+              "uid": "meerkat-db"
             },
             "editorMode": "code",
             "expr": "network_monitoring_rtt_max{host_id=~\"$host_id\"}",
@@ -349,7 +349,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "ee4b2fvtkitxcc"
+          "uid": "meerkat-db"
         },
         "fieldConfig": {
           "defaults": {
@@ -431,7 +431,7 @@
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "ee4b2fvtkitxcc"
+              "uid": "meerkat-db"
             },
             "editorMode": "code",
             "expr": "network_monitoring_tcp_throughput{host_id=~\"$host_id\"}",
@@ -446,7 +446,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "ee4b2fvtkitxcc"
+          "uid": "meerkat-db"
         },
         "fieldConfig": {
           "defaults": {
@@ -528,7 +528,7 @@
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "ee4b2fvtkitxcc"
+              "uid": "meerkat-db"
             },
             "editorMode": "code",
             "expr": "network_monitoring_tcp_retries{host_id=~\"$host_id\"}",
@@ -556,7 +556,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "ee4b2fvtkitxcc"
+          "uid": "meerkat-db"
         },
         "fieldConfig": {
           "defaults": {
@@ -638,7 +638,7 @@
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "ee4b2fvtkitxcc"
+              "uid": "meerkat-db"
             },
             "editorMode": "code",
             "expr": "network_monitoring_udp_throughput{host_id=~\"$host_id\"}",
@@ -653,7 +653,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "ee4b2fvtkitxcc"
+          "uid": "meerkat-db"
         },
         "fieldConfig": {
           "defaults": {
@@ -735,7 +735,7 @@
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "ee4b2fvtkitxcc"
+              "uid": "meerkat-db"
             },
             "editorMode": "code",
             "expr": "network_monitoring_udp_packet_loss{host_id=~\"$host_id\"}",


### PR DESCRIPTION
Added dashboards for Meerkat CPU, RAM, and storage. These shows the benchmarking results from meerkat hardware benchmarks.
Also added network monitoring dashboard, which shows the current network availability on the cloud.

These all pull from the MeerkatDB, which needs to be added as a new datasoruce.

### Submitter:

Have you:

* [yes] Checked the latest commit runs on a Grafana instance using the aq personality `openstack-grafana`? 
* [yes] Dashboards have clearly labelled panels, and are easy to read?

### Reviewer:

As part of reviewing this PR the changes must be tested on a Grafana instance. To do this:

* [ ] Spin up a machine with the aq personality `openstack-grafana`

* [ ] In `/etc/grafana/grafana.ini` under `[server]` comment out: domain, root_url, http_addr. Restart Grafana

* [ ] As Root change the git branch the dashboard folder (`/etc/grafana/provisioning/dashboards`) using: `git switch <branch-name>`
  
* [ ] Restart the Grafana service: `systemctl restart grafana-server`

Have you:

* [ ] Checked whether the panels are clear and easy to read?

