### PR TITLE
MAINT: Switch the dashboard datasource

### DIFF
--- a/Slots-Available/openstack_slots_available.json
+++ b/Slots-Available/openstack_slots_available.json
@@ -1,958 +1,1218 @@
 {
-  "annotations": {
-    "list": [
-      {
-        "builtIn": 1,
-        "datasource": {
-          "type": "datasource",
-          "uid": "grafana"
-        },
-        "enable": true,
-        "hide": true,
-        "iconColor": "rgba(0, 211, 255, 1)",
-        "name": "Annotations & Alerts",
-        "type": "dashboard"
-      }
-    ]
-  },
-  "editable": true,
-  "fiscalYearStartMonth": 0,
-  "graphTooltip": 0,
-  "id": 20,
-  "links": [],
-  "panels": [
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 0
-      },
-      "id": 19,
-      "panels": [],
-      "title": "L* Flavors",
-      "type": "row"
+  "apiVersion": "dashboard.grafana.app/v2",
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "slots_available",
+    "namespace": "default",
+    "uid": "rDD8XOc5P0MBbpl90RX7XnDSyMd5tWFyUL3X6nuB5VMX",
+    "resourceVersion": "1776852270002988",
+    "generation": 3,
+    "creationTimestamp": "2025-11-24T10:11:50Z",
+    "labels": {
+      "grafana.app/deprecatedInternalID": "19"
     },
-    {
-      "datasource": {
-        "type": "influxdb",
-        "uid": "${Environment}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "dark-blue"
-              },
-              {
-                "color": "dark-red",
-                "value": 0
-              },
-              {
-                "color": "#EAB839",
-                "value": 1
-              },
-              {
-                "color": "dark-green",
-                "value": 20
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 11,
-        "w": 24,
-        "x": 0,
-        "y": 1
-      },
-      "id": 4,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "mean"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "11.6.0",
-      "targets": [
-        {
-          "alias": "$tag_flavor",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${Environment}"
-          },
-          "groupBy": [
-            {
-              "params": [
-                "flavor"
-              ],
-              "type": "tag"
-            }
-          ],
-          "measurement": "SlotsAvailable",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "SELECT last(\"SlotsAvailable\") FROM \"SlotsAvailable\" WHERE (\"instance\" =~  /^${Instance:text}$/  AND \"flavor\" !~ /.*test.*/ AND \"flavor\" !~ /.*temp.*/ AND \"flavor\" =~ /^l.*/) AND $timeFilter GROUP BY \"flavor\"",
-          "rawQuery": true,
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "SlotsAvailable"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "last"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "flavor",
-              "operator": "!~",
-              "value": "/.*test.*/"
-            },
-            {
-              "condition": "AND",
-              "key": "flavor",
-              "operator": "!~",
-              "value": "/.*temp.*/"
-            },
-            {
-              "condition": "AND",
-              "key": "flavor",
-              "operator": "=~",
-              "value": "/^l.*/"
-            }
-          ]
-        }
-      ],
-      "title": "L* flavors",
-      "type": "stat"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 12
-      },
-      "id": 22,
-      "panels": [],
-      "title": "GPU Visualisation",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "influxdb",
-        "uid": "${Environment}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "dark-blue"
-              },
-              {
-                "color": "dark-red",
-                "value": 0
-              },
-              {
-                "color": "dark-yellow",
-                "value": 1
-              },
-              {
-                "color": "dark-green",
-                "value": 20
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 13,
-        "x": 0,
-        "y": 13
-      },
-      "id": 5,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "mean"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "11.6.0",
-      "targets": [
-        {
-          "alias": "$tag_flavor",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${Environment}"
-          },
-          "groupBy": [
-            {
-              "params": [
-                "flavor"
-              ],
-              "type": "tag"
-            }
-          ],
-          "measurement": "SlotsAvailable",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "SELECT last(\"SlotsAvailable\") FROM \"SlotsAvailable\" WHERE (\"instance\" =~  /^${Instance:text}$/  AND \"flavor\" !~ /.*test.*/ AND \"flavor\" !~ /.*temp.*/ AND \"flavor\" =~ /g-rtx4000.*/) AND $timeFilter GROUP BY \"flavor\"",
-          "rawQuery": true,
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "SlotsAvailable"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "last"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "flavor",
-              "operator": "!~",
-              "value": "/.*test.*/"
-            },
-            {
-              "condition": "AND",
-              "key": "flavor",
-              "operator": "!~",
-              "value": "/.*temp.*/"
-            },
-            {
-              "condition": "AND",
-              "key": "flavor",
-              "operator": "=~",
-              "value": "/g-rtx4000.*/"
-            }
-          ]
-        }
-      ],
-      "title": "RTX4000* flavors",
-      "type": "stat"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 19
-      },
-      "id": 21,
-      "panels": [],
-      "title": "GPU Compute",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "influxdb",
-        "uid": "${Environment}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "dark-blue"
-              },
-              {
-                "color": "dark-red",
-                "value": 0
-              },
-              {
-                "color": "dark-yellow",
-                "value": 1
-              },
-              {
-                "color": "dark-green",
-                "value": 20
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 24,
-        "x": 0,
-        "y": 20
-      },
-      "id": 8,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "mean"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "11.6.0",
-      "targets": [
-        {
-          "alias": "$tag_flavor",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${Environment}"
-          },
-          "groupBy": [
-            {
-              "params": [
-                "flavor"
-              ],
-              "type": "tag"
-            }
-          ],
-          "measurement": "SlotsAvailable",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "SELECT last(\"SlotsAvailable\") FROM \"SlotsAvailable\" WHERE (\"instance\" =~  /^${Instance:text}$/  AND \"flavor\" !~ /.*test.*/ AND \"flavor\" !~ /.*temp.*/ AND \"flavor\" =~ /g-a100.*/) AND $timeFilter GROUP BY \"flavor\"",
-          "rawQuery": true,
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "SlotsAvailable"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "last"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "flavor",
-              "operator": "!~",
-              "value": "/.*test.*/"
-            },
-            {
-              "condition": "AND",
-              "key": "flavor",
-              "operator": "!~",
-              "value": "/.*temp.*/"
-            },
-            {
-              "condition": "AND",
-              "key": "flavor",
-              "operator": "=~",
-              "value": "/g-a100.*/"
-            }
-          ]
-        }
-      ],
-      "title": "A100 flavors",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "influxdb",
-        "uid": "${Environment}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "dark-blue"
-              },
-              {
-                "color": "dark-red",
-                "value": 0
-              },
-              {
-                "color": "dark-yellow",
-                "value": 1
-              },
-              {
-                "color": "dark-green",
-                "value": 20
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 13,
-        "x": 0,
-        "y": 26
-      },
-      "id": 6,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "mean"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "11.6.0",
-      "targets": [
-        {
-          "alias": "$tag_flavor",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${Environment}"
-          },
-          "groupBy": [
-            {
-              "params": [
-                "flavor"
-              ],
-              "type": "tag"
-            }
-          ],
-          "measurement": "SlotsAvailable",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "SELECT last(\"SlotsAvailable\") FROM \"SlotsAvailable\" WHERE (\"instance\" =~  /^${Instance:text}$/  AND \"flavor\" !~ /.*test.*/ AND \"flavor\" !~ /.*temp.*/ AND \"flavor\" =~ /g-v100.*/) AND $timeFilter GROUP BY \"flavor\"",
-          "rawQuery": true,
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "SlotsAvailable"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "last"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "flavor",
-              "operator": "!~",
-              "value": "/.*test.*/"
-            },
-            {
-              "condition": "AND",
-              "key": "flavor",
-              "operator": "!~",
-              "value": "/.*temp.*/"
-            },
-            {
-              "condition": "AND",
-              "key": "flavor",
-              "operator": "=~",
-              "value": "/g-v100.*/"
-            }
-          ]
-        }
-      ],
-      "title": "V100* flavors",
-      "type": "stat"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 33
-      },
-      "id": 20,
-      "panels": [],
-      "title": "Decommissioned Flavors",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "influxdb",
-        "uid": "${Environment}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "dark-blue"
-              },
-              {
-                "color": "dark-red",
-                "value": 0
-              },
-              {
-                "color": "dark-yellow",
-                "value": 1
-              },
-              {
-                "color": "dark-green",
-                "value": 20
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 24,
-        "x": 0,
-        "y": 34
-      },
-      "id": 2,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "mean"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "11.6.0",
-      "targets": [
-        {
-          "alias": "$tag_flavor",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${Environment}"
-          },
-          "groupBy": [
-            {
-              "params": [
-                "flavor"
-              ],
-              "type": "tag"
-            }
-          ],
-          "measurement": "SlotsAvailable",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "SELECT last(\"SlotsAvailable\") FROM \"SlotsAvailable\" WHERE (\"flavor\" !~ /.*test.*/ AND \"flavor\" !~ /.*temp.*/ AND \"flavor\" =~ /^c.*/) AND $timeFilter GROUP BY \"flavor\"",
-          "rawQuery": true,
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "SlotsAvailable"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "last"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "flavor",
-              "operator": "!~",
-              "value": "/.*test.*/"
-            },
-            {
-              "condition": "AND",
-              "key": "flavor",
-              "operator": "!~",
-              "value": "/.*temp.*/"
-            },
-            {
-              "condition": "AND",
-              "key": "flavor",
-              "operator": "=~",
-              "value": "/^c.*/"
-            }
-          ]
-        }
-      ],
-      "title": "C* flavors",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "influxdb",
-        "uid": "${Environment}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "dark-blue"
-              },
-              {
-                "color": "dark-red",
-                "value": 0
-              },
-              {
-                "color": "dark-yellow",
-                "value": 10
-              },
-              {
-                "color": "dark-green",
-                "value": 20
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 11,
-        "x": 0,
-        "y": 41
-      },
-      "id": 7,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "mean"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "11.6.0",
-      "targets": [
-        {
-          "alias": "$tag_flavor",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${Environment}"
-          },
-          "groupBy": [
-            {
-              "params": [
-                "flavor"
-              ],
-              "type": "tag"
-            }
-          ],
-          "measurement": "SlotsAvailable",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "SlotsAvailable"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "last"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "flavor",
-              "operator": "!~",
-              "value": "/.*test.*/"
-            },
-            {
-              "condition": "AND",
-              "key": "flavor",
-              "operator": "!~",
-              "value": "/.*temp.*/"
-            },
-            {
-              "condition": "AND",
-              "key": "flavor",
-              "operator": "=~",
-              "value": "/g-p100.*/"
-            }
-          ]
-        }
-      ],
-      "title": "P100 flavors",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "influxdb",
-        "uid": "${Environment}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "dark-blue"
-              },
-              {
-                "color": "dark-red",
-                "value": 0
-              },
-              {
-                "color": "dark-yellow",
-                "value": 10
-              },
-              {
-                "color": "dark-green",
-                "value": 20
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 13,
-        "x": 11,
-        "y": 41
-      },
-      "id": 3,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "mean"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "11.6.0",
-      "targets": [
-        {
-          "alias": "$tag_flavor",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${Environment}"
-          },
-          "groupBy": [
-            {
-              "params": [
-                "flavor"
-              ],
-              "type": "tag"
-            }
-          ],
-          "measurement": "SlotsAvailable",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "SlotsAvailable"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "last"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "flavor",
-              "operator": "!~",
-              "value": "/.*test.*/"
-            },
-            {
-              "condition": "AND",
-              "key": "flavor",
-              "operator": "!~",
-              "value": "/.*temp.*/"
-            },
-            {
-              "condition": "AND",
-              "key": "flavor",
-              "operator": "=~",
-              "value": "/g-p4000.*/"
-            }
-          ]
-        }
-      ],
-      "title": "P4000* flavors",
-      "type": "stat"
+    "annotations": {
+      "grafana.app/createdBy": "provisioning:",
+      "grafana.app/folder": "",
+      "grafana.app/managedBy": "classic-file-provisioning",
+      "grafana.app/managerAllowsEdits": "true",
+      "grafana.app/managerId": "default",
+      "grafana.app/saved-from-ui": "Grafana v13.0.1 (a100054f)",
+      "grafana.app/sourceChecksum": "ca5a9dbf9338a50c538ce8f6ffdbeaf0",
+      "grafana.app/sourcePath": "/etc/grafana/provisioning/dashboards/openstack_slots_available.json",
+      "grafana.app/sourceTimestamp": "1776851161000",
+      "grafana.app/updatedBy": "user:ef52vu9o4f2tcf",
+      "grafana.app/updatedTimestamp": "2026-04-22T10:04:29Z"
     }
-  ],
-  "preload": false,
-  "refresh": "",
-  "schemaVersion": 41,
-  "tags": [],
-  "templating": {
-    "list": [
+  },
+  "spec": {
+    "annotations": [
       {
-        "allowCustomValue": false,
-        "current": {
-          "text": "CloudInfluxDB",
-          "value": "CloudInfluxDB"
-        },
-        "includeAll": false,
-        "name": "Instance",
-        "options": [
+        "kind": "AnnotationQuery",
+        "spec": {
+          "query": {
+            "kind": "DataQuery",
+            "group": "grafana",
+            "version": "v0",
+            "datasource": {
+              "name": "grafana"
+            },
+            "spec": {}
+          },
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "builtIn": true
+        }
+      }
+    ],
+    "cursorSync": "Off",
+    "editable": true,
+    "elements": {
+      "panel-2": {
+        "kind": "Panel",
+        "spec": {
+          "id": 2,
+          "title": "C* flavors",
+          "description": "",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "influxdb",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "${Environment}"
+                      },
+                      "spec": {
+                        "alias": "$tag_flavor",
+                        "groupBy": [
+                          {
+                            "params": [
+                              "flavor"
+                            ],
+                            "type": "tag"
+                          }
+                        ],
+                        "measurement": "SlotsAvailable",
+                        "orderByTime": "ASC",
+                        "policy": "default",
+                        "query": "SELECT last(\"SlotsAvailable\") FROM \"SlotsAvailable\" WHERE (\"flavor\" !~ /.*test.*/ AND \"flavor\" !~ /.*temp.*/ AND \"flavor\" =~ /^c.*/) AND $timeFilter GROUP BY \"flavor\"",
+                        "rawQuery": true,
+                        "resultFormat": "time_series",
+                        "select": [
+                          [
+                            {
+                              "params": [
+                                "SlotsAvailable"
+                              ],
+                              "type": "field"
+                            },
+                            {
+                              "params": [],
+                              "type": "last"
+                            }
+                          ]
+                        ],
+                        "tags": [
+                          {
+                            "key": "flavor",
+                            "operator": "!~",
+                            "value": "/.*test.*/"
+                          },
+                          {
+                            "condition": "AND",
+                            "key": "flavor",
+                            "operator": "!~",
+                            "value": "/.*temp.*/"
+                          },
+                          {
+                            "condition": "AND",
+                            "key": "flavor",
+                            "operator": "=~",
+                            "value": "/^c.*/"
+                          }
+                        ]
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.1",
+            "spec": {
+              "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "mean"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "dark-blue"
+                      },
+                      {
+                        "value": 0,
+                        "color": "dark-red"
+                      },
+                      {
+                        "value": 1,
+                        "color": "dark-yellow"
+                      },
+                      {
+                        "value": 20,
+                        "color": "dark-green"
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-3": {
+        "kind": "Panel",
+        "spec": {
+          "id": 3,
+          "title": "P4000* flavors",
+          "description": "",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "influxdb",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "${Environment}"
+                      },
+                      "spec": {
+                        "alias": "$tag_flavor",
+                        "groupBy": [
+                          {
+                            "params": [
+                              "flavor"
+                            ],
+                            "type": "tag"
+                          }
+                        ],
+                        "measurement": "SlotsAvailable",
+                        "orderByTime": "ASC",
+                        "policy": "default",
+                        "resultFormat": "time_series",
+                        "select": [
+                          [
+                            {
+                              "params": [
+                                "SlotsAvailable"
+                              ],
+                              "type": "field"
+                            },
+                            {
+                              "params": [],
+                              "type": "last"
+                            }
+                          ]
+                        ],
+                        "tags": [
+                          {
+                            "key": "flavor",
+                            "operator": "!~",
+                            "value": "/.*test.*/"
+                          },
+                          {
+                            "condition": "AND",
+                            "key": "flavor",
+                            "operator": "!~",
+                            "value": "/.*temp.*/"
+                          },
+                          {
+                            "condition": "AND",
+                            "key": "flavor",
+                            "operator": "=~",
+                            "value": "/g-p4000.*/"
+                          }
+                        ]
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.1",
+            "spec": {
+              "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "mean"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "dark-blue"
+                      },
+                      {
+                        "value": 0,
+                        "color": "dark-red"
+                      },
+                      {
+                        "value": 10,
+                        "color": "dark-yellow"
+                      },
+                      {
+                        "value": 20,
+                        "color": "dark-green"
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-4": {
+        "kind": "Panel",
+        "spec": {
+          "id": 4,
+          "title": "L* flavors",
+          "description": "",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "influxdb",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "${Environment}"
+                      },
+                      "spec": {
+                        "alias": "$tag_flavor",
+                        "groupBy": [
+                          {
+                            "params": [
+                              "flavor"
+                            ],
+                            "type": "tag"
+                          }
+                        ],
+                        "measurement": "SlotsAvailable",
+                        "orderByTime": "ASC",
+                        "policy": "default",
+                        "query": "SELECT last(\"SlotsAvailable\") FROM \"SlotsAvailable\" WHERE (\"instance\" =~  /^${Instance:text}$/  AND \"flavor\" !~ /.*test.*/ AND \"flavor\" !~ /.*temp.*/ AND \"flavor\" =~ /^l.*/) AND $timeFilter GROUP BY \"flavor\"",
+                        "rawQuery": true,
+                        "resultFormat": "time_series",
+                        "select": [
+                          [
+                            {
+                              "params": [
+                                "SlotsAvailable"
+                              ],
+                              "type": "field"
+                            },
+                            {
+                              "params": [],
+                              "type": "last"
+                            }
+                          ]
+                        ],
+                        "tags": [
+                          {
+                            "key": "flavor",
+                            "operator": "!~",
+                            "value": "/.*test.*/"
+                          },
+                          {
+                            "condition": "AND",
+                            "key": "flavor",
+                            "operator": "!~",
+                            "value": "/.*temp.*/"
+                          },
+                          {
+                            "condition": "AND",
+                            "key": "flavor",
+                            "operator": "=~",
+                            "value": "/^l.*/"
+                          }
+                        ]
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.1",
+            "spec": {
+              "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "mean"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "dark-blue"
+                      },
+                      {
+                        "value": 0,
+                        "color": "dark-red"
+                      },
+                      {
+                        "value": 1,
+                        "color": "#EAB839"
+                      },
+                      {
+                        "value": 20,
+                        "color": "dark-green"
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-5": {
+        "kind": "Panel",
+        "spec": {
+          "id": 5,
+          "title": "RTX4000* flavors",
+          "description": "",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "influxdb",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "${Environment}"
+                      },
+                      "spec": {
+                        "alias": "$tag_flavor",
+                        "groupBy": [
+                          {
+                            "params": [
+                              "flavor"
+                            ],
+                            "type": "tag"
+                          }
+                        ],
+                        "measurement": "SlotsAvailable",
+                        "orderByTime": "ASC",
+                        "policy": "default",
+                        "query": "SELECT last(\"SlotsAvailable\") FROM \"SlotsAvailable\" WHERE (\"instance\" =~  /^${Instance:text}$/  AND \"flavor\" !~ /.*test.*/ AND \"flavor\" !~ /.*temp.*/ AND \"flavor\" =~ /g-rtx4000.*/) AND $timeFilter GROUP BY \"flavor\"",
+                        "rawQuery": true,
+                        "resultFormat": "time_series",
+                        "select": [
+                          [
+                            {
+                              "params": [
+                                "SlotsAvailable"
+                              ],
+                              "type": "field"
+                            },
+                            {
+                              "params": [],
+                              "type": "last"
+                            }
+                          ]
+                        ],
+                        "tags": [
+                          {
+                            "key": "flavor",
+                            "operator": "!~",
+                            "value": "/.*test.*/"
+                          },
+                          {
+                            "condition": "AND",
+                            "key": "flavor",
+                            "operator": "!~",
+                            "value": "/.*temp.*/"
+                          },
+                          {
+                            "condition": "AND",
+                            "key": "flavor",
+                            "operator": "=~",
+                            "value": "/g-rtx4000.*/"
+                          }
+                        ]
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.1",
+            "spec": {
+              "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "mean"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "dark-blue"
+                      },
+                      {
+                        "value": 0,
+                        "color": "dark-red"
+                      },
+                      {
+                        "value": 1,
+                        "color": "dark-yellow"
+                      },
+                      {
+                        "value": 20,
+                        "color": "dark-green"
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-6": {
+        "kind": "Panel",
+        "spec": {
+          "id": 6,
+          "title": "V100* flavors",
+          "description": "",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "influxdb",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "${Environment}"
+                      },
+                      "spec": {
+                        "alias": "$tag_flavor",
+                        "groupBy": [
+                          {
+                            "params": [
+                              "flavor"
+                            ],
+                            "type": "tag"
+                          }
+                        ],
+                        "measurement": "SlotsAvailable",
+                        "orderByTime": "ASC",
+                        "policy": "default",
+                        "query": "SELECT last(\"SlotsAvailable\") FROM \"SlotsAvailable\" WHERE (\"instance\" =~  /^${Instance:text}$/  AND \"flavor\" !~ /.*test.*/ AND \"flavor\" !~ /.*temp.*/ AND \"flavor\" =~ /g-v100.*/) AND $timeFilter GROUP BY \"flavor\"",
+                        "rawQuery": true,
+                        "resultFormat": "time_series",
+                        "select": [
+                          [
+                            {
+                              "params": [
+                                "SlotsAvailable"
+                              ],
+                              "type": "field"
+                            },
+                            {
+                              "params": [],
+                              "type": "last"
+                            }
+                          ]
+                        ],
+                        "tags": [
+                          {
+                            "key": "flavor",
+                            "operator": "!~",
+                            "value": "/.*test.*/"
+                          },
+                          {
+                            "condition": "AND",
+                            "key": "flavor",
+                            "operator": "!~",
+                            "value": "/.*temp.*/"
+                          },
+                          {
+                            "condition": "AND",
+                            "key": "flavor",
+                            "operator": "=~",
+                            "value": "/g-v100.*/"
+                          }
+                        ]
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.1",
+            "spec": {
+              "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "mean"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "dark-blue"
+                      },
+                      {
+                        "value": 0,
+                        "color": "dark-red"
+                      },
+                      {
+                        "value": 1,
+                        "color": "dark-yellow"
+                      },
+                      {
+                        "value": 20,
+                        "color": "dark-green"
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-7": {
+        "kind": "Panel",
+        "spec": {
+          "id": 7,
+          "title": "P100 flavors",
+          "description": "",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "influxdb",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "${Environment}"
+                      },
+                      "spec": {
+                        "alias": "$tag_flavor",
+                        "groupBy": [
+                          {
+                            "params": [
+                              "flavor"
+                            ],
+                            "type": "tag"
+                          }
+                        ],
+                        "measurement": "SlotsAvailable",
+                        "orderByTime": "ASC",
+                        "policy": "default",
+                        "resultFormat": "time_series",
+                        "select": [
+                          [
+                            {
+                              "params": [
+                                "SlotsAvailable"
+                              ],
+                              "type": "field"
+                            },
+                            {
+                              "params": [],
+                              "type": "last"
+                            }
+                          ]
+                        ],
+                        "tags": [
+                          {
+                            "key": "flavor",
+                            "operator": "!~",
+                            "value": "/.*test.*/"
+                          },
+                          {
+                            "condition": "AND",
+                            "key": "flavor",
+                            "operator": "!~",
+                            "value": "/.*temp.*/"
+                          },
+                          {
+                            "condition": "AND",
+                            "key": "flavor",
+                            "operator": "=~",
+                            "value": "/g-p100.*/"
+                          }
+                        ]
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.1",
+            "spec": {
+              "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "mean"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "dark-blue"
+                      },
+                      {
+                        "value": 0,
+                        "color": "dark-red"
+                      },
+                      {
+                        "value": 10,
+                        "color": "dark-yellow"
+                      },
+                      {
+                        "value": 20,
+                        "color": "dark-green"
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-8": {
+        "kind": "Panel",
+        "spec": {
+          "id": 8,
+          "title": "A100 flavors",
+          "description": "",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "influxdb",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "${Environment}"
+                      },
+                      "spec": {
+                        "alias": "$tag_flavor",
+                        "groupBy": [
+                          {
+                            "params": [
+                              "flavor"
+                            ],
+                            "type": "tag"
+                          }
+                        ],
+                        "measurement": "SlotsAvailable",
+                        "orderByTime": "ASC",
+                        "policy": "default",
+                        "query": "SELECT last(\"SlotsAvailable\") FROM \"SlotsAvailable\" WHERE (\"instance\" =~  /^${Instance:text}$/  AND \"flavor\" !~ /.*test.*/ AND \"flavor\" !~ /.*temp.*/ AND \"flavor\" =~ /g-a100.*/) AND $timeFilter GROUP BY \"flavor\"",
+                        "rawQuery": true,
+                        "resultFormat": "time_series",
+                        "select": [
+                          [
+                            {
+                              "params": [
+                                "SlotsAvailable"
+                              ],
+                              "type": "field"
+                            },
+                            {
+                              "params": [],
+                              "type": "last"
+                            }
+                          ]
+                        ],
+                        "tags": [
+                          {
+                            "key": "flavor",
+                            "operator": "!~",
+                            "value": "/.*test.*/"
+                          },
+                          {
+                            "condition": "AND",
+                            "key": "flavor",
+                            "operator": "!~",
+                            "value": "/.*temp.*/"
+                          },
+                          {
+                            "condition": "AND",
+                            "key": "flavor",
+                            "operator": "=~",
+                            "value": "/g-a100.*/"
+                          }
+                        ]
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.1",
+            "spec": {
+              "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "mean"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "dark-blue"
+                      },
+                      {
+                        "value": 0,
+                        "color": "dark-red"
+                      },
+                      {
+                        "value": 1,
+                        "color": "dark-yellow"
+                      },
+                      {
+                        "value": 20,
+                        "color": "dark-green"
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      }
+    },
+    "layout": {
+      "kind": "RowsLayout",
+      "spec": {
+        "rows": [
           {
-            "selected": true,
-            "text": "Prod",
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "title": "L* Flavors",
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 24,
+                        "height": 11,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-4"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "title": "GPU Visualisation",
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 13,
+                        "height": 6,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-5"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "title": "GPU Compute",
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 24,
+                        "height": 6,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-8"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 6,
+                        "width": 13,
+                        "height": 7,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-6"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "title": "Decommissioned Flavors",
+              "collapse": true,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 24,
+                        "height": 7,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-2"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 7,
+                        "width": 11,
+                        "height": 6,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-7"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 11,
+                        "y": 7,
+                        "width": 13,
+                        "height": 6,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-3"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    "links": [],
+    "liveNow": false,
+    "preload": false,
+    "tags": [],
+    "timeSettings": {
+      "timezone": "browser",
+      "from": "now-1h",
+      "to": "now",
+      "autoRefresh": "",
+      "autoRefreshIntervals": [
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "hideTimepicker": false,
+      "fiscalYearStartMonth": 0
+    },
+    "title": "OpenStack Slots Available",
+    "variables": [
+      {
+        "kind": "CustomVariable",
+        "spec": {
+          "name": "Instance",
+          "query": "Prod : CloudInfluxDB, Preprod : DevCloudInfluxDB",
+          "current": {
+            "text": "CloudInfluxDB",
             "value": "CloudInfluxDB"
           },
-          {
-            "selected": false,
-            "text": "Preprod",
-            "value": "DevCloudInfluxDB"
-          }
-        ],
-        "query": "Prod : CloudInfluxDB, Preprod : DevCloudInfluxDB",
-        "type": "custom"
+          "options": [
+            {
+              "selected": true,
+              "text": "Prod",
+              "value": "CloudInfluxDB"
+            },
+            {
+              "selected": false,
+              "text": "Preprod",
+              "value": "DevCloudInfluxDB"
+            }
+          ],
+          "multi": false,
+          "includeAll": false,
+          "hide": "dontHide",
+          "skipUrlSync": false,
+          "allowCustomValue": false,
+          "valuesFormat": "csv"
+        }
       },
       {
-        "allowCustomValue": false,
-        "current": {
-          "text": "CloudInfluxDB",
-          "value": "openstack_grafana"
-        },
-        "description": "Production or Development cloud data",
-        "name": "Environment",
-        "options": [],
-        "query": "influxdb",
-        "refresh": 1,
-        "regex": "${Instance:value}",
-        "type": "datasource"
+        "kind": "DatasourceVariable",
+        "spec": {
+          "name": "Environment",
+          "pluginId": "influxdb",
+          "refresh": "onDashboardLoad",
+          "regex": "DevCloudInfluxDB",
+          "current": {
+            "text": "CloudInfluxDB",
+            "value": "openstack_grafana"
+          },
+          "options": [],
+          "multi": false,
+          "includeAll": false,
+          "hide": "dontHide",
+          "skipUrlSync": false,
+          "description": "Production or Development cloud data",
+          "allowCustomValue": false
+        }
       }
     ]
-  },
-  "time": {
-    "from": "now-1h",
-    "to": "now"
-  },
-  "timepicker": {
-    "refresh_intervals": [
-      "10s",
-      "30s",
-      "1m",
-      "5m",
-      "15m",
-      "30m",
-      "1h",
-      "2h",
-      "1d"
-    ]
-  },
-  "timezone": "",
-  "title": "OpenStack Slots Available",
-  "uid": "slots_available",
-  "version": 6
+  }
 }


### PR DESCRIPTION
### Description:

Switch the datasource from influx1 to the devinflux. The devinflux does not have any sensitive data and this dashboard is going to become public.

https://grafana.nubes.rl.ac.uk/d/slots_available/openstack-slots-available

---

### Reviewer:

As part of reviewing this PR the changes must be tested on a Grafana instance. To do this:

* [x] SSH into the dev-grafana instance. `ssh ubuntu@dev-grafana.nubes.rl.ac.uk`
      
* [x] As Root change the git branch the dashboard folder (`/etc/grafana/provisioning/dashboards`) using: `git switch <branch-name>`
  
* [x] Restart the Grafana service: `systemctl restart grafana-server`

Have you:

* [ ] Checked whether the panels are clear and easy to read?

* [ ] Changed the branch back to main once the branch is merged
