### PR TITLE
BUG: Reverting dashboards to API v1

### DIFF
--- a/Virtual-Machines/vm_power_and_carbon_method_1.json
+++ b/Virtual-Machines/vm_power_and_carbon_method_1.json
@@ -1,3772 +1,2979 @@
 {
-  "annotations": [
-    {
-      "kind": "AnnotationQuery",
-      "spec": {
-        "builtIn": true,
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
         "name": "Annotations & Alerts",
-        "query": {
-          "group": "grafana",
-          "kind": "DataQuery",
-          "spec": {},
-          "version": "v0"
-        }
+        "type": "dashboard"
       }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 28,
+      "title": "Main",
+      "type": "row"
+    },
+    {
+      "gridPos": {
+        "h": 18,
+        "w": 18,
+        "x": 0,
+        "y": 1
+      },
+      "id": 8,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "# ⚡Virtual Machine Power & Carbon Emissions Dashboard Method 1\nThis dashboard estimates the **power consumption** and **carbon emissions** of an OpenStack Virtual Machine (VM) over a selected time period.<br>\nThe calculation is based on the **VM CPU usage relative to the total CPU usage of the hypervisor host.**\n> ⚠️ The results represent an **approximation**, not an exact measurement of VM energy usage.<br>\n> ⚠️ This dashboard supports Compute (CPU) flavours only.<br>\n`GPU flavours are not supported and may produce incorrect estimates.`\n\n## 🧭 How to Use This Dashboard\n\n1. **Select your VM Instance Name:**<br>\nUse the Instance Name dropdown at the top of the dashboard to select your VM.<br>\n2. **Handle duplicate VM names (if applicable):**<br>\n-If multiple VMs share the same name:<br>\n-Go to: https://openstack.stfc.ac.uk<br>\n-Navigate to: Project → Instances<br>\n-Find the correct VM and copy its Instance ID (UUID)<br>\n-In Grafana, after selecting the instance name, choose the corresponding VM UUID from the UUID variable dropdown<br>\n5. **Select the time range:**<br>\nChoose the time period you want to analyse using the time picker.<br>\n6. **View the Results, the dashboard will display:**<br>\nEstimated VM power consumption<br>\nEstimated carbon emissions\n\n## 🧮 Calculation Method\nThe VM power consumption is estimated using proportional CPU utilisation:<br>\n      `VM Power ≈ Hypervisor Power × (VM CPU Usage / Hypervisor CPU Usage)`<br>\nThis method attributes a share of the physical server's power consumption to each VM based on its relative CPU activity.\n\n\n## ⚠️ Important Limitations\nThe VM power attribution is calculated only from CPU resources and does not include:<br>\n- Memory (RAM) usage\n- Disk storage and I/O activity\n- Network traffic\n- GPU or accelerator usage<br>\n\nWorkloads that rely heavily on these resources may therefore have their actual energy usage under- or over-estimated.<br>\nTherefore, this dashboard currently supports only Compute (CPU) flavours.<br>\nGPU flavours are not supported and will not produce accurate power or carbon estimates.\n## 🌱 Purpose of This Dashboard:\nThis dashboard helps users:\n- Understand the energy footprint of their virtual machines.\n- Estimate carbon emissions of workloads\n- Support sustainability and energy awareness in using STFC Cloud",
+        "mode": "markdown"
+      },
+      "pluginVersion": "13.0.2",
+      "targets": [],
+      "title": "",
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "remote_write_prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "h"
+        }
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 6,
+        "x": 18,
+        "y": 1
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "13.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "code",
+          "expr": "$__range_s / 3600",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Duration",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "remote_write_prometheus"
+      },
+      "description": "UK average carbon intensity in 2025 is 126 gCO2/kWh. <br>\nSource: <br>\nhttps://www.carbonbrief.org/analysis-uk-renewables-enjoy-record-year-in-2025-but-gas-power-still-rises/ <br>\nhttps://www.energydashboard.co.uk/insights/2025-review",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "massg"
+        }
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 6,
+        "x": 18,
+        "y": 4
+      },
+      "id": 23,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "13.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "ipmi_dcmi_power_consumption_watts{instance=~\"$Hypervisor\"}",
+          "instant": false,
+          "legendFormat": "HypervisorPower{{label_name}}",
+          "range": true,
+          "refId": "Hypervisor Power"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "exemplar": false,
+          "expr": "irate(libvirt_domain_info_cpu_time_seconds_total{job=\"libvirt_exporter\", domain=\"$domain\"}[5m])",
+          "instant": false,
+          "legendFormat": "VM CPU Usage{{label_name}}",
+          "range": true,
+          "refId": "VM CPU Usage"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "sum by(instance) (irate(libvirt_domain_info_cpu_time_seconds_total{job=\"libvirt_exporter\", instance=~\"$Hypervisor\"}[5m]))",
+          "instant": false,
+          "legendFormat": "Hypervisor CPU Usage {{label_name}}",
+          "range": true,
+          "refId": "Hypervisor CPU Usage"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "code",
+          "expr": "$__range_s / 3600",
+          "instant": false,
+          "legendFormat": "Duration(hour){{label_name}}",
+          "range": true,
+          "refId": "Duration (hour)"
+        }
+      ],
+      "title": "🌍 Total Carbon Emission (gCO2)",
+      "transformations": [
+        {
+          "id": "calculateField",
+          "options": {
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "VM CPU Usage"
+                }
+              },
+              "operator": "/",
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Hypervisor CPU Usage "
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "VM Power (W)",
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "HypervisorPower"
+                }
+              },
+              "operator": "*",
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "VM CPU Usage / Hypervisor CPU Usage "
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": false
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Total VM Energy (Wh)",
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "VM Power (W)"
+                }
+              },
+              "operator": "*",
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Duration(hour)"
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": false
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Total VM Energy (kWh)",
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Total VM Energy (Wh)"
+                }
+              },
+              "operator": "/",
+              "right": {
+                "fixed": "1000"
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "pue",
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Total VM Energy (kWh)"
+                }
+              },
+              "operator": "*",
+              "right": {
+                "fixed": "1.3"
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "gco2",
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "pue"
+                }
+              },
+              "operator": "*",
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "$carbon_intensity"
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "include": [
+                "Total VM Energy (kWh) * 1.3"
+              ],
+              "reducer": "sum"
+            },
+            "replaceFields": true
+          }
+        }
+      ],
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "remote_write_prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "massg"
+        }
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 6,
+        "x": 18,
+        "y": 7
+      },
+      "id": 24,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "13.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "ipmi_dcmi_power_consumption_watts{instance=~\"$Hypervisor\"}",
+          "instant": false,
+          "legendFormat": "HypervisorPower{{label_name}}",
+          "range": true,
+          "refId": "Hypervisor Power"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "exemplar": false,
+          "expr": "irate(libvirt_domain_info_cpu_time_seconds_total{job=\"libvirt_exporter\", domain=\"$domain\"}[5m])",
+          "instant": false,
+          "legendFormat": "VM CPU Usage{{label_name}}",
+          "range": true,
+          "refId": "VM CPU Usage"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "sum by(instance) (irate(libvirt_domain_info_cpu_time_seconds_total{job=\"libvirt_exporter\", instance=~\"$Hypervisor\"}[5m]))",
+          "instant": false,
+          "legendFormat": "Hypervisor CPU Usage {{label_name}}",
+          "range": true,
+          "refId": "Hypervisor CPU Usage"
+        }
+      ],
+      "title": "🌍 Carbon Emission of VM per Hour (gCO2)",
+      "transformations": [
+        {
+          "id": "calculateField",
+          "options": {
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "VM CPU Usage"
+                }
+              },
+              "operator": "/",
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Hypervisor CPU Usage "
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "VM Power (W)",
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "HypervisorPower"
+                }
+              },
+              "operator": "*",
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "VM CPU Usage / Hypervisor CPU Usage "
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": true
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "VM Power (kW)",
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "VM Power (W)"
+                }
+              },
+              "operator": "/",
+              "right": {
+                "fixed": "1000"
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "pue",
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "VM Power (kW)"
+                }
+              },
+              "operator": "*",
+              "right": {
+                "fixed": "1.3"
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": false
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "pue"
+                }
+              },
+              "operator": "*",
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "$carbon_intensity"
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": true
+          }
+        }
+      ],
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "remote_write_prometheus"
+      },
+      "description": "VM Power = (VM_CPU_core / Host_CPU_core) * [Host_Min_Watts + VM_Utilisation * (Host_Max_Watts - Host_Min_Watts)]",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "watt"
+        }
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 6,
+        "x": 18,
+        "y": 10
+      },
+      "id": 21,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "13.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "ipmi_dcmi_power_consumption_watts{instance=~\"$Hypervisor\"}",
+          "instant": false,
+          "legendFormat": "HypervisorPower{{label_name}}",
+          "range": true,
+          "refId": "Hypervisor Power"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "exemplar": false,
+          "expr": "irate(libvirt_domain_info_cpu_time_seconds_total{job=\"libvirt_exporter\", domain=\"$domain\"}[5m])",
+          "instant": false,
+          "legendFormat": "VM CPU Usage{{label_name}}",
+          "range": true,
+          "refId": "VM CPU Usage"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "sum by(instance) (irate(libvirt_domain_info_cpu_time_seconds_total{job=\"libvirt_exporter\", instance=~\"$Hypervisor\"}[5m]))",
+          "instant": false,
+          "legendFormat": "Hypervisor CPU Usage {{label_name}}",
+          "range": true,
+          "refId": "Hypervisor CPU Usage"
+        }
+      ],
+      "title": "⚡VM Average Power (W)",
+      "transformations": [
+        {
+          "id": "calculateField",
+          "options": {
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "VM CPU Usage"
+                }
+              },
+              "operator": "/",
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Hypervisor CPU Usage "
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "VM Power (W)",
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "HypervisorPower"
+                }
+              },
+              "operator": "*",
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "VM CPU Usage / Hypervisor CPU Usage "
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": false
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "pue",
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "VM Power (W)"
+                }
+              },
+              "operator": "*",
+              "right": {
+                "fixed": "1.3"
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": true
+          }
+        }
+      ],
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "remote_write_prometheus"
+      },
+      "description": "Equation: <br>\nVM Power ≈ Hypervisor Power × (VM CPU Usage / Hypervisor CPU Usage)",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "watth"
+        }
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 6,
+        "x": 18,
+        "y": 13
+      },
+      "id": 22,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "13.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "ipmi_dcmi_power_consumption_watts{instance=~\"$Hypervisor\"}",
+          "instant": false,
+          "legendFormat": "HypervisorPower{{label_name}}",
+          "range": true,
+          "refId": "Hypervisor Power"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "exemplar": false,
+          "expr": "irate(libvirt_domain_info_cpu_time_seconds_total{job=\"libvirt_exporter\", domain=\"$domain\"}[5m])",
+          "instant": false,
+          "legendFormat": "VM CPU Usage{{label_name}}",
+          "range": true,
+          "refId": "VM CPU Usage"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "sum by(instance) (irate(libvirt_domain_info_cpu_time_seconds_total{job=\"libvirt_exporter\", instance=~\"$Hypervisor\"}[5m]))",
+          "instant": false,
+          "legendFormat": "Hypervisor CPU Usage {{label_name}}",
+          "range": true,
+          "refId": "Hypervisor CPU Usage"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "code",
+          "expr": "$__range_s / 3600",
+          "instant": false,
+          "legendFormat": "Duration(hour){{label_name}}",
+          "range": true,
+          "refId": "Duration (hour)"
+        }
+      ],
+      "title": "⚡VM Total Energy Used (kWh)",
+      "transformations": [
+        {
+          "id": "calculateField",
+          "options": {
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "VM CPU Usage"
+                }
+              },
+              "operator": "/",
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Hypervisor CPU Usage "
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "VM Power (W)",
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "HypervisorPower"
+                }
+              },
+              "operator": "*",
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "VM CPU Usage / Hypervisor CPU Usage "
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": false
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "VM Power (W)"
+                }
+              },
+              "operator": "*",
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Duration(hour)"
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": true
+          }
+        }
+      ],
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "remote_write_prometheus"
+      },
+      "description": "As of 17th March 2026 <br>\nAverage electricity cost report by HPC Operation Costing Report is £0.21 per kWh. <br>\nElectricity Cost = Total Energy * 0.21 <br>\nSource: <br>\nhttp://cacti-master-virt.di.stfc.ac.uk/Information/CostingForm.php",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "currencyGBP"
+        }
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 6,
+        "x": 18,
+        "y": 16
+      },
+      "id": 25,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "13.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "ipmi_dcmi_power_consumption_watts{instance=~\"$Hypervisor\"}",
+          "instant": false,
+          "legendFormat": "HypervisorPower{{label_name}}",
+          "range": true,
+          "refId": "Hypervisor Power"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "exemplar": false,
+          "expr": "irate(libvirt_domain_info_cpu_time_seconds_total{job=\"libvirt_exporter\", domain=\"$domain\"}[5m])",
+          "instant": false,
+          "legendFormat": "VM CPU Usage{{label_name}}",
+          "range": true,
+          "refId": "VM CPU Usage"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "sum by(instance) (irate(libvirt_domain_info_cpu_time_seconds_total{job=\"libvirt_exporter\", instance=~\"$Hypervisor\"}[5m]))",
+          "instant": false,
+          "legendFormat": "Hypervisor CPU Usage {{label_name}}",
+          "range": true,
+          "refId": "Hypervisor CPU Usage"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "code",
+          "expr": "$__range_s / 3600",
+          "instant": false,
+          "legendFormat": "Duration(hour){{label_name}}",
+          "range": true,
+          "refId": "Duration (hour)"
+        }
+      ],
+      "title": "⚡ VM Energy Cost",
+      "transformations": [
+        {
+          "id": "calculateField",
+          "options": {
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "VM CPU Usage"
+                }
+              },
+              "operator": "/",
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Hypervisor CPU Usage "
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "VM Power (W)",
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "HypervisorPower"
+                }
+              },
+              "operator": "*",
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "VM CPU Usage / Hypervisor CPU Usage "
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": false
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Total VM Energy (Wh)",
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "VM Power (W)"
+                }
+              },
+              "operator": "*",
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Duration(hour)"
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": false
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Total VM Energy (kWh)",
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Total VM Energy (Wh)"
+                }
+              },
+              "operator": "/",
+              "right": {
+                "fixed": "1000"
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "pue",
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Total VM Energy (kWh)"
+                }
+              },
+              "operator": "*",
+              "right": {
+                "fixed": "1.3"
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": false
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "£",
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "pue"
+                }
+              },
+              "operator": "*",
+              "right": {
+                "fixed": "0.21"
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": true
+          }
+        }
+      ],
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "remote_write_prometheus"
+      },
+      "description": "Petrol cars had 143 gCO2/km\n=> 7150 gCO2 per hour driving (assuming 50km/h or 30mph)\nSource: 2022 UK GOV (https://www.gov.uk/government/statistics/vehicle-licensing-statistics-2022/vehicle-licensing-statistics-2022#carbon-co2-emissions-for-new-vehicle-registrations)",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "h"
+        }
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 19
+      },
+      "id": 26,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "13.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "ipmi_dcmi_power_consumption_watts{instance=~\"$Hypervisor\"}",
+          "instant": false,
+          "legendFormat": "HypervisorPower{{label_name}}",
+          "range": true,
+          "refId": "Hypervisor Power"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "exemplar": false,
+          "expr": "irate(libvirt_domain_info_cpu_time_seconds_total{job=\"libvirt_exporter\", domain=\"$domain\"}[5m])",
+          "instant": false,
+          "legendFormat": "VM CPU Usage{{label_name}}",
+          "range": true,
+          "refId": "VM CPU Usage"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "sum by(instance) (irate(libvirt_domain_info_cpu_time_seconds_total{job=\"libvirt_exporter\", instance=~\"$Hypervisor\"}[5m]))",
+          "instant": false,
+          "legendFormat": "Hypervisor CPU Usage {{label_name}}",
+          "range": true,
+          "refId": "Hypervisor CPU Usage"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "code",
+          "expr": "$__range_s / 3600",
+          "instant": false,
+          "legendFormat": "Duration(hour){{label_name}}",
+          "range": true,
+          "refId": "Duration (hour)"
+        }
+      ],
+      "title": "🚗 Driving a Petrol Car for",
+      "transformations": [
+        {
+          "id": "calculateField",
+          "options": {
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "VM CPU Usage"
+                }
+              },
+              "operator": "/",
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Hypervisor CPU Usage "
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "VM Power (W)",
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "HypervisorPower"
+                }
+              },
+              "operator": "*",
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "VM CPU Usage / Hypervisor CPU Usage "
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": false
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Total VM Energy (Wh)",
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "VM Power (W)"
+                }
+              },
+              "operator": "*",
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Duration(hour)"
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": false
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Total VM Energy (kWh)",
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Total VM Energy (Wh)"
+                }
+              },
+              "operator": "/",
+              "right": {
+                "fixed": "1000"
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "pue",
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Total VM Energy (kWh)"
+                }
+              },
+              "operator": "*",
+              "right": {
+                "fixed": "1.3"
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": false
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "gCO2",
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "pue"
+                }
+              },
+              "operator": "*",
+              "right": {
+                "fixed": "126"
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Car",
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "gCO2"
+                }
+              },
+              "operator": "/",
+              "right": {
+                "fixed": "7150"
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": true
+          }
+        }
+      ],
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "remote_write_prometheus"
+      },
+      "description": "A tree absorbs approximately 25kg of CO2 per year. <br>\nSource: <br>\nhttps://ecotree.green/en/how-much-co2-does-a-tree-absorb",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "Trees"
+        }
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 19
+      },
+      "id": 27,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "13.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "ipmi_dcmi_power_consumption_watts{instance=~\"$Hypervisor\"}",
+          "instant": false,
+          "legendFormat": "HypervisorPower{{label_name}}",
+          "range": true,
+          "refId": "Hypervisor Power"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "exemplar": false,
+          "expr": "irate(libvirt_domain_info_cpu_time_seconds_total{job=\"libvirt_exporter\", domain=\"$domain\"}[5m])",
+          "instant": false,
+          "legendFormat": "VM CPU Usage{{label_name}}",
+          "range": true,
+          "refId": "VM CPU Usage"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "sum by(instance) (irate(libvirt_domain_info_cpu_time_seconds_total{job=\"libvirt_exporter\", instance=~\"$Hypervisor\"}[5m]))",
+          "instant": false,
+          "legendFormat": "Hypervisor CPU Usage {{label_name}}",
+          "range": true,
+          "refId": "Hypervisor CPU Usage"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "code",
+          "expr": "$__range_s / 3600",
+          "instant": false,
+          "legendFormat": "Duration(hour){{label_name}}",
+          "range": true,
+          "refId": "Duration (hour)"
+        }
+      ],
+      "title": "🌳 Carbon absorbed in 1 year by",
+      "transformations": [
+        {
+          "id": "calculateField",
+          "options": {
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "VM CPU Usage"
+                }
+              },
+              "operator": "/",
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Hypervisor CPU Usage "
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "VM Power (W)",
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "HypervisorPower"
+                }
+              },
+              "operator": "*",
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "VM CPU Usage / Hypervisor CPU Usage "
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": false
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Total VM Energy (Wh)",
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "VM Power (W)"
+                }
+              },
+              "operator": "*",
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Duration(hour)"
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": false
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Total VM Energy (kWh)",
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Total VM Energy (Wh)"
+                }
+              },
+              "operator": "/",
+              "right": {
+                "fixed": "1000"
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "pue",
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Total VM Energy (kWh)"
+                }
+              },
+              "operator": "*",
+              "right": {
+                "fixed": "1.3"
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": false
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "gCO2",
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "pue"
+                }
+              },
+              "operator": "*",
+              "right": {
+                "fixed": "126"
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Tree",
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "gCO2"
+                }
+              },
+              "operator": "/",
+              "right": {
+                "fixed": "25000"
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": true
+          }
+        }
+      ],
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "remote_write_prometheus"
+      },
+      "description": "VM Power = (VM_CPU_core / Host_CPU_core) * [Host_Min_Watts + VM_Utilisation * (Host_Max_Watts - Host_Min_Watts)]",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": true,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "watt"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 23
+      },
+      "id": 1,
+      "options": {
+        "annotations": {
+          "clustering": -1,
+          "multiLane": false
+        },
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "mean",
+            "diffperc"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "13.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "ipmi_dcmi_power_consumption_watts{instance=~\"$Hypervisor\"}",
+          "instant": false,
+          "legendFormat": "HypervisorPower{{label_name}}",
+          "range": true,
+          "refId": "Hypervisor Power"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "exemplar": false,
+          "expr": "irate(libvirt_domain_info_cpu_time_seconds_total{job=\"libvirt_exporter\", domain=\"$domain\"}[5m])",
+          "instant": false,
+          "legendFormat": "VM CPU Usage{{label_name}}",
+          "range": true,
+          "refId": "VM CPU Usage"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "sum by(instance) (irate(libvirt_domain_info_cpu_time_seconds_total{job=\"libvirt_exporter\", instance=~\"$Hypervisor\"}[5m]))",
+          "instant": false,
+          "legendFormat": "Hypervisor CPU Usage {{label_name}}",
+          "range": true,
+          "refId": "Hypervisor CPU Usage"
+        }
+      ],
+      "title": "VM Power Timeline",
+      "transformations": [
+        {
+          "id": "calculateField",
+          "options": {
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "VM CPU Usage"
+                }
+              },
+              "operator": "/",
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Hypervisor CPU Usage "
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "VM Power (W)",
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "HypervisorPower"
+                }
+              },
+              "operator": "*",
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "VM CPU Usage / Hypervisor CPU Usage "
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": true
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 31
+      },
+      "id": 29,
+      "title": "Host & VM Metrics",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "remote_write_prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        }
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 32
+      },
+      "id": 11,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "text": {
+          "valueSize": 25
+        },
+        "textMode": "name",
+        "wideLayout": true
+      },
+      "pluginVersion": "13.0.1+security-01",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "exemplar": false,
+          "expr": "max by (hostname, aggregates) (\r\n  (\r\n    libvirt_domain_info_meta{job=\"libvirt_exporter\", uuid=~\"$uuid\"}\r\n  )\r\n  * on(instance)\r\n  group_left(hostname, aggregates)\r\n  label_replace(\r\n    openstack_nova_current_workload,\r\n    \"instance\", \"$1\", \"hostname\", \"(.*)\"\r\n  )\r\n)",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "Host: {{hostname}} Model: {{aggregates}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "VM Location",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "remote_write_prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        }
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 6,
+        "y": 32
+      },
+      "id": 12,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "text": {
+          "valueSize": 25
+        },
+        "textMode": "name",
+        "wideLayout": true
+      },
+      "pluginVersion": "13.0.1+security-01",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "libvirt_domain_info_meta{job=\"libvirt_exporter\", uuid=~\"$uuid\"}",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "{{flavor}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "VM Flavour",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "remote_write_prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        }
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 10,
+        "y": 32
+      },
+      "id": 14,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "text": {
+          "valueSize": 25
+        },
+        "textMode": "name",
+        "wideLayout": true
+      },
+      "pluginVersion": "13.0.1+security-01",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "libvirt_domain_info_meta{job=\"libvirt_exporter\", uuid=~\"$uuid\"}",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "{{project_name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "VM - Project Name",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "remote_write_prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        }
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 16,
+        "y": 32
+      },
+      "id": 13,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "text": {
+          "valueSize": 25
+        },
+        "textMode": "name",
+        "wideLayout": true
+      },
+      "pluginVersion": "13.0.1+security-01",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "exemplar": false,
+          "expr": "count by(instance) (libvirt_domain_info_meta{job=\"libvirt_exporter\", instance=~\"$Hypervisor\"})",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Number of instances(VM) on Host",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "remote_write_prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        }
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 3,
+        "x": 0,
+        "y": 36
+      },
+      "id": 15,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "text": {
+          "valueSize": 25
+        },
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "13.0.1+security-01",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "last_over_time(openstack_placement_resource_total{hostname=~\"$Hypervisor\", resourcetype=~\"PCPU|VCU\"}[10m])",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Host CPU Core",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "remote_write_prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        }
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 3,
+        "x": 3,
+        "y": 36
+      },
+      "id": 16,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "text": {
+          "valueSize": 25
+        },
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "13.0.1+security-01",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "exemplar": false,
+          "expr": "libvirt_domain_info_virtual_cpus{job=\"libvirt_exporter\", domain=~\"$domain\"} * on(instance) libvirt_domain_info_meta{job=\"libvirt_exporter\", uuid=~\"$uuid\"}",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "VM CPU Core",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "remote_write_prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        }
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 6,
+        "y": 36
+      },
+      "id": 17,
+      "options": {
+        "annotations": {
+          "clustering": -1,
+          "multiLane": false
+        },
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "13.0.1+security-01",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "exemplar": false,
+          "expr": "max(max_over_time(ipmi_dcmi_power_consumption_watts{instance=~\"$Hypervisor\"}[$__range]))",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Host Max Watts",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "remote_write_prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        }
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 10,
+        "y": 36
+      },
+      "id": 18,
+      "options": {
+        "annotations": {
+          "clustering": -1,
+          "multiLane": false
+        },
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "13.0.1+security-01",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "exemplar": false,
+          "expr": "min(min_over_time(ipmi_dcmi_power_consumption_watts{instance=~\"$Hypervisor\"}[$__range]))",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Host Min Watts",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "remote_write_prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        }
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 14,
+        "y": 36
+      },
+      "id": 19,
+      "options": {
+        "annotations": {
+          "clustering": -1,
+          "multiLane": false
+        },
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "13.0.1+security-01",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "rate(libvirt_domain_info_cpu_time_seconds_total{job=\"libvirt_exporter\", domain=~\"$domain\"}[5m])\r\n/\r\non(domain)\r\ngroup_left()\r\nlibvirt_domain_info_virtual_cpus{job=\"libvirt_exporter\"}",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "VM CPU Utilisation (by VCPU Count)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "remote_write_prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        }
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 18,
+        "y": 36
+      },
+      "id": 20,
+      "options": {
+        "annotations": {
+          "clustering": -1,
+          "multiLane": false
+        },
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "13.0.1+security-01",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "exemplar": false,
+          "expr": "sum by(instance) (irate(libvirt_domain_info_cpu_time_seconds_total{job=\"libvirt_exporter\", domain=~\"$domain\"}[2m])) * on(instance) libvirt_domain_info_meta{job=\"libvirt_exporter\", uuid=~\"$uuid\"}",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Host CPU Utilisation",
+      "type": "timeseries"
     }
   ],
-  "cursorSync": "Off",
-  "editable": true,
-  "elements": {
-    "panel-1": {
-      "kind": "Panel",
-      "spec": {
-        "data": {
-          "kind": "QueryGroup",
-          "spec": {
-            "queries": [
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "expr": "ipmi_dcmi_power_consumption_watts{instance=~\"$Hypervisor\"}",
-                      "instant": false,
-                      "legendFormat": "HypervisorPower{{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "Hypervisor Power"
-                }
-              },
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "exemplar": false,
-                      "expr": "irate(libvirt_domain_info_cpu_time_seconds_total{job=\"libvirt_exporter\", domain=\"$domain\"}[5m])",
-                      "instant": false,
-                      "legendFormat": "VM CPU Usage{{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "VM CPU Usage"
-                }
-              },
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "expr": "sum by(instance) (irate(libvirt_domain_info_cpu_time_seconds_total{job=\"libvirt_exporter\", instance=~\"$Hypervisor\"}[5m]))",
-                      "instant": false,
-                      "legendFormat": "Hypervisor CPU Usage {{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "Hypervisor CPU Usage"
-                }
-              }
-            ],
-            "queryOptions": {},
-            "transformations": [
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "VM CPU Usage"
-                        }
-                      },
-                      "operator": "/",
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Hypervisor CPU Usage "
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    }
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "alias": "VM Power (W)",
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "HypervisorPower"
-                        }
-                      },
-                      "operator": "*",
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "VM CPU Usage / Hypervisor CPU Usage "
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    },
-                    "replaceFields": true
-                  }
-                }
-              }
-            ]
-          }
-        },
-        "description": "VM Power = (VM_CPU_core / Host_CPU_core) * [Host_Min_Watts + VM_Utilisation * (Host_Max_Watts - Host_Min_Watts)]",
-        "id": 1,
-        "links": [],
-        "title": "VM Power Timeline",
-        "vizConfig": {
-          "group": "timeseries",
-          "kind": "VizConfig",
-          "spec": {
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "palette-classic"
-                },
-                "custom": {
-                  "axisBorderShow": true,
-                  "axisCenteredZero": false,
-                  "axisColorMode": "text",
-                  "axisLabel": "",
-                  "axisPlacement": "auto",
-                  "barAlignment": 0,
-                  "barWidthFactor": 0.6,
-                  "drawStyle": "line",
-                  "fillOpacity": 0,
-                  "gradientMode": "none",
-                  "hideFrom": {
-                    "legend": false,
-                    "tooltip": false,
-                    "viz": false
-                  },
-                  "insertNulls": false,
-                  "lineInterpolation": "linear",
-                  "lineStyle": {
-                    "fill": "solid"
-                  },
-                  "lineWidth": 1,
-                  "pointSize": 5,
-                  "scaleDistribution": {
-                    "type": "linear"
-                  },
-                  "showPoints": "auto",
-                  "showValues": false,
-                  "spanNulls": false,
-                  "stacking": {
-                    "group": "A",
-                    "mode": "none"
-                  },
-                  "thresholdsStyle": {
-                    "mode": "off"
-                  }
-                },
-                "fieldMinMax": false,
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "watt"
-              },
-              "overrides": []
-            },
-            "options": {
-              "annotations": {
-                "clustering": -1,
-                "multiLane": false
-              },
-              "legend": {
-                "calcs": [
-                  "lastNotNull",
-                  "mean",
-                  "diffperc"
-                ],
-                "displayMode": "list",
-                "placement": "bottom",
-                "showLegend": true
-              },
-              "tooltip": {
-                "hideZeros": false,
-                "mode": "single",
-                "sort": "none"
-              }
-            }
-          },
-          "version": "13.0.2"
-        }
-      }
-    },
-    "panel-11": {
-      "kind": "Panel",
-      "spec": {
-        "data": {
-          "kind": "QueryGroup",
-          "spec": {
-            "queries": [
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "exemplar": false,
-                      "expr": "max by (hostname, aggregates) (\r\n  (\r\n    libvirt_domain_info_meta{job=\"libvirt_exporter\", uuid=~\"$uuid\"}\r\n  )\r\n  * on(instance)\r\n  group_left(hostname, aggregates)\r\n  label_replace(\r\n    openstack_nova_current_workload,\r\n    \"instance\", \"$1\", \"hostname\", \"(.*)\"\r\n  )\r\n)",
-                      "format": "time_series",
-                      "instant": false,
-                      "interval": "",
-                      "legendFormat": "Host: {{hostname}} Model: {{aggregates}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "A"
-                }
-              }
-            ],
-            "queryOptions": {},
-            "transformations": []
-          }
-        },
-        "description": "",
-        "id": 11,
-        "links": [],
-        "title": "VM Location",
-        "vizConfig": {
-          "group": "stat",
-          "kind": "VizConfig",
-          "spec": {
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "thresholds"
-                },
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                }
-              },
-              "overrides": []
-            },
-            "options": {
-              "colorMode": "none",
-              "graphMode": "none",
-              "justifyMode": "auto",
-              "orientation": "auto",
-              "percentChangeColorMode": "standard",
-              "reduceOptions": {
-                "calcs": [
-                  "lastNotNull"
-                ],
-                "fields": "",
-                "values": false
-              },
-              "showPercentChange": false,
-              "text": {
-                "valueSize": 25
-              },
-              "textMode": "name",
-              "wideLayout": true
-            }
-          },
-          "version": "13.0.1+security-01"
-        }
-      }
-    },
-    "panel-12": {
-      "kind": "Panel",
-      "spec": {
-        "data": {
-          "kind": "QueryGroup",
-          "spec": {
-            "queries": [
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "code",
-                      "exemplar": false,
-                      "expr": "libvirt_domain_info_meta{job=\"libvirt_exporter\", uuid=~\"$uuid\"}",
-                      "format": "time_series",
-                      "instant": false,
-                      "interval": "",
-                      "legendFormat": "{{flavor}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "A"
-                }
-              }
-            ],
-            "queryOptions": {},
-            "transformations": []
-          }
-        },
-        "description": "",
-        "id": 12,
-        "links": [],
-        "title": "VM Flavour",
-        "vizConfig": {
-          "group": "stat",
-          "kind": "VizConfig",
-          "spec": {
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "thresholds"
-                },
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                }
-              },
-              "overrides": []
-            },
-            "options": {
-              "colorMode": "none",
-              "graphMode": "none",
-              "justifyMode": "auto",
-              "orientation": "auto",
-              "percentChangeColorMode": "standard",
-              "reduceOptions": {
-                "calcs": [
-                  "lastNotNull"
-                ],
-                "fields": "",
-                "values": false
-              },
-              "showPercentChange": false,
-              "text": {
-                "valueSize": 25
-              },
-              "textMode": "name",
-              "wideLayout": true
-            }
-          },
-          "version": "13.0.1+security-01"
-        }
-      }
-    },
-    "panel-13": {
-      "kind": "Panel",
-      "spec": {
-        "data": {
-          "kind": "QueryGroup",
-          "spec": {
-            "queries": [
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "exemplar": false,
-                      "expr": "count by(instance) (libvirt_domain_info_meta{job=\"libvirt_exporter\", instance=~\"$Hypervisor\"})",
-                      "format": "time_series",
-                      "instant": false,
-                      "interval": "",
-                      "legendFormat": "__auto",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "A"
-                }
-              }
-            ],
-            "queryOptions": {},
-            "transformations": []
-          }
-        },
-        "description": "",
-        "id": 13,
-        "links": [],
-        "title": "Number of instances(VM) on Host",
-        "vizConfig": {
-          "group": "stat",
-          "kind": "VizConfig",
-          "spec": {
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "thresholds"
-                },
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                }
-              },
-              "overrides": []
-            },
-            "options": {
-              "colorMode": "none",
-              "graphMode": "none",
-              "justifyMode": "auto",
-              "orientation": "auto",
-              "percentChangeColorMode": "standard",
-              "reduceOptions": {
-                "calcs": [
-                  "lastNotNull"
-                ],
-                "fields": "",
-                "values": false
-              },
-              "showPercentChange": false,
-              "text": {
-                "valueSize": 25
-              },
-              "textMode": "name",
-              "wideLayout": true
-            }
-          },
-          "version": "13.0.1+security-01"
-        }
-      }
-    },
-    "panel-14": {
-      "kind": "Panel",
-      "spec": {
-        "data": {
-          "kind": "QueryGroup",
-          "spec": {
-            "queries": [
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "code",
-                      "exemplar": false,
-                      "expr": "libvirt_domain_info_meta{job=\"libvirt_exporter\", uuid=~\"$uuid\"}",
-                      "format": "time_series",
-                      "instant": false,
-                      "interval": "",
-                      "legendFormat": "{{project_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "A"
-                }
-              }
-            ],
-            "queryOptions": {},
-            "transformations": []
-          }
-        },
-        "description": "",
-        "id": 14,
-        "links": [],
-        "title": "VM - Project Name",
-        "vizConfig": {
-          "group": "stat",
-          "kind": "VizConfig",
-          "spec": {
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "thresholds"
-                },
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                }
-              },
-              "overrides": []
-            },
-            "options": {
-              "colorMode": "none",
-              "graphMode": "none",
-              "justifyMode": "auto",
-              "orientation": "auto",
-              "percentChangeColorMode": "standard",
-              "reduceOptions": {
-                "calcs": [
-                  "lastNotNull"
-                ],
-                "fields": "",
-                "values": false
-              },
-              "showPercentChange": false,
-              "text": {
-                "valueSize": 25
-              },
-              "textMode": "name",
-              "wideLayout": true
-            }
-          },
-          "version": "13.0.1+security-01"
-        }
-      }
-    },
-    "panel-15": {
-      "kind": "Panel",
-      "spec": {
-        "data": {
-          "kind": "QueryGroup",
-          "spec": {
-            "queries": [
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "code",
-                      "exemplar": false,
-                      "expr": "last_over_time(openstack_placement_resource_total{hostname=~\"$Hypervisor\", resourcetype=~\"PCPU|VCU\"}[10m])",
-                      "format": "time_series",
-                      "instant": false,
-                      "interval": "",
-                      "legendFormat": "__auto",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "A"
-                }
-              }
-            ],
-            "queryOptions": {},
-            "transformations": []
-          }
-        },
-        "description": "",
-        "id": 15,
-        "links": [],
-        "title": "Host CPU Core",
-        "vizConfig": {
-          "group": "stat",
-          "kind": "VizConfig",
-          "spec": {
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "thresholds"
-                },
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                }
-              },
-              "overrides": []
-            },
-            "options": {
-              "colorMode": "none",
-              "graphMode": "none",
-              "justifyMode": "auto",
-              "orientation": "auto",
-              "percentChangeColorMode": "standard",
-              "reduceOptions": {
-                "calcs": [
-                  "lastNotNull"
-                ],
-                "fields": "",
-                "values": false
-              },
-              "showPercentChange": false,
-              "text": {
-                "valueSize": 25
-              },
-              "textMode": "value",
-              "wideLayout": true
-            }
-          },
-          "version": "13.0.1+security-01"
-        }
-      }
-    },
-    "panel-16": {
-      "kind": "Panel",
-      "spec": {
-        "data": {
-          "kind": "QueryGroup",
-          "spec": {
-            "queries": [
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "exemplar": false,
-                      "expr": "libvirt_domain_info_virtual_cpus{job=\"libvirt_exporter\", domain=~\"$domain\"} * on(instance) libvirt_domain_info_meta{job=\"libvirt_exporter\", uuid=~\"$uuid\"}",
-                      "format": "time_series",
-                      "instant": false,
-                      "interval": "",
-                      "legendFormat": "__auto",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "A"
-                }
-              }
-            ],
-            "queryOptions": {},
-            "transformations": []
-          }
-        },
-        "description": "",
-        "id": 16,
-        "links": [],
-        "title": "VM CPU Core",
-        "vizConfig": {
-          "group": "stat",
-          "kind": "VizConfig",
-          "spec": {
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "thresholds"
-                },
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                }
-              },
-              "overrides": []
-            },
-            "options": {
-              "colorMode": "none",
-              "graphMode": "none",
-              "justifyMode": "auto",
-              "orientation": "auto",
-              "percentChangeColorMode": "standard",
-              "reduceOptions": {
-                "calcs": [
-                  "lastNotNull"
-                ],
-                "fields": "",
-                "values": false
-              },
-              "showPercentChange": false,
-              "text": {
-                "valueSize": 25
-              },
-              "textMode": "value",
-              "wideLayout": true
-            }
-          },
-          "version": "13.0.1+security-01"
-        }
-      }
-    },
-    "panel-17": {
-      "kind": "Panel",
-      "spec": {
-        "data": {
-          "kind": "QueryGroup",
-          "spec": {
-            "queries": [
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "exemplar": false,
-                      "expr": "max(max_over_time(ipmi_dcmi_power_consumption_watts{instance=~\"$Hypervisor\"}[$__range]))",
-                      "format": "time_series",
-                      "instant": false,
-                      "interval": "",
-                      "legendFormat": "__auto",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "A"
-                }
-              }
-            ],
-            "queryOptions": {},
-            "transformations": []
-          }
-        },
-        "description": "",
-        "id": 17,
-        "links": [],
-        "title": "Host Max Watts",
-        "vizConfig": {
-          "group": "timeseries",
-          "kind": "VizConfig",
-          "spec": {
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "palette-classic"
-                },
-                "custom": {
-                  "axisBorderShow": false,
-                  "axisCenteredZero": false,
-                  "axisColorMode": "text",
-                  "axisLabel": "",
-                  "axisPlacement": "auto",
-                  "barAlignment": 0,
-                  "barWidthFactor": 0.6,
-                  "drawStyle": "line",
-                  "fillOpacity": 0,
-                  "gradientMode": "none",
-                  "hideFrom": {
-                    "legend": false,
-                    "tooltip": false,
-                    "viz": false
-                  },
-                  "insertNulls": false,
-                  "lineInterpolation": "linear",
-                  "lineWidth": 1,
-                  "pointSize": 5,
-                  "scaleDistribution": {
-                    "type": "linear"
-                  },
-                  "showPoints": "auto",
-                  "showValues": false,
-                  "spanNulls": false,
-                  "stacking": {
-                    "group": "A",
-                    "mode": "none"
-                  },
-                  "thresholdsStyle": {
-                    "mode": "off"
-                  }
-                },
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                }
-              },
-              "overrides": []
-            },
-            "options": {
-              "annotations": {
-                "clustering": -1,
-                "multiLane": false
-              },
-              "legend": {
-                "calcs": [],
-                "displayMode": "list",
-                "placement": "bottom",
-                "showLegend": true
-              },
-              "tooltip": {
-                "hideZeros": false,
-                "mode": "single",
-                "sort": "none"
-              }
-            }
-          },
-          "version": "13.0.1+security-01"
-        }
-      }
-    },
-    "panel-18": {
-      "kind": "Panel",
-      "spec": {
-        "data": {
-          "kind": "QueryGroup",
-          "spec": {
-            "queries": [
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "exemplar": false,
-                      "expr": "min(min_over_time(ipmi_dcmi_power_consumption_watts{instance=~\"$Hypervisor\"}[$__range]))",
-                      "format": "time_series",
-                      "instant": false,
-                      "interval": "",
-                      "legendFormat": "__auto",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "A"
-                }
-              }
-            ],
-            "queryOptions": {},
-            "transformations": []
-          }
-        },
-        "description": "",
-        "id": 18,
-        "links": [],
-        "title": "Host Min Watts",
-        "vizConfig": {
-          "group": "timeseries",
-          "kind": "VizConfig",
-          "spec": {
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "palette-classic"
-                },
-                "custom": {
-                  "axisBorderShow": false,
-                  "axisCenteredZero": false,
-                  "axisColorMode": "text",
-                  "axisLabel": "",
-                  "axisPlacement": "auto",
-                  "barAlignment": 0,
-                  "barWidthFactor": 0.6,
-                  "drawStyle": "line",
-                  "fillOpacity": 0,
-                  "gradientMode": "none",
-                  "hideFrom": {
-                    "legend": false,
-                    "tooltip": false,
-                    "viz": false
-                  },
-                  "insertNulls": false,
-                  "lineInterpolation": "linear",
-                  "lineWidth": 1,
-                  "pointSize": 5,
-                  "scaleDistribution": {
-                    "type": "linear"
-                  },
-                  "showPoints": "auto",
-                  "showValues": false,
-                  "spanNulls": false,
-                  "stacking": {
-                    "group": "A",
-                    "mode": "none"
-                  },
-                  "thresholdsStyle": {
-                    "mode": "off"
-                  }
-                },
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                }
-              },
-              "overrides": []
-            },
-            "options": {
-              "annotations": {
-                "clustering": -1,
-                "multiLane": false
-              },
-              "legend": {
-                "calcs": [],
-                "displayMode": "list",
-                "placement": "bottom",
-                "showLegend": true
-              },
-              "tooltip": {
-                "hideZeros": false,
-                "mode": "single",
-                "sort": "none"
-              }
-            }
-          },
-          "version": "13.0.1+security-01"
-        }
-      }
-    },
-    "panel-19": {
-      "kind": "Panel",
-      "spec": {
-        "data": {
-          "kind": "QueryGroup",
-          "spec": {
-            "queries": [
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "code",
-                      "exemplar": false,
-                      "expr": "rate(libvirt_domain_info_cpu_time_seconds_total{job=\"libvirt_exporter\", domain=~\"$domain\"}[5m])\r\n/\r\non(domain)\r\ngroup_left()\r\nlibvirt_domain_info_virtual_cpus{job=\"libvirt_exporter\"}",
-                      "format": "time_series",
-                      "instant": false,
-                      "interval": "",
-                      "legendFormat": "__auto",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "A"
-                }
-              }
-            ],
-            "queryOptions": {},
-            "transformations": []
-          }
-        },
-        "description": "",
-        "id": 19,
-        "links": [],
-        "title": "VM CPU Utilisation (by VCPU Count)",
-        "vizConfig": {
-          "group": "timeseries",
-          "kind": "VizConfig",
-          "spec": {
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "palette-classic"
-                },
-                "custom": {
-                  "axisBorderShow": false,
-                  "axisCenteredZero": false,
-                  "axisColorMode": "text",
-                  "axisLabel": "",
-                  "axisPlacement": "auto",
-                  "barAlignment": 0,
-                  "barWidthFactor": 0.6,
-                  "drawStyle": "line",
-                  "fillOpacity": 0,
-                  "gradientMode": "none",
-                  "hideFrom": {
-                    "legend": false,
-                    "tooltip": false,
-                    "viz": false
-                  },
-                  "insertNulls": false,
-                  "lineInterpolation": "linear",
-                  "lineWidth": 1,
-                  "pointSize": 5,
-                  "scaleDistribution": {
-                    "type": "linear"
-                  },
-                  "showPoints": "auto",
-                  "showValues": false,
-                  "spanNulls": false,
-                  "stacking": {
-                    "group": "A",
-                    "mode": "none"
-                  },
-                  "thresholdsStyle": {
-                    "mode": "off"
-                  }
-                },
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "percentunit"
-              },
-              "overrides": []
-            },
-            "options": {
-              "annotations": {
-                "clustering": -1,
-                "multiLane": false
-              },
-              "legend": {
-                "calcs": [],
-                "displayMode": "list",
-                "placement": "bottom",
-                "showLegend": true
-              },
-              "tooltip": {
-                "hideZeros": false,
-                "mode": "single",
-                "sort": "none"
-              }
-            }
-          },
-          "version": "13.0.1+security-01"
-        }
-      }
-    },
-    "panel-20": {
-      "kind": "Panel",
-      "spec": {
-        "data": {
-          "kind": "QueryGroup",
-          "spec": {
-            "queries": [
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "exemplar": false,
-                      "expr": "sum by(instance) (irate(libvirt_domain_info_cpu_time_seconds_total{job=\"libvirt_exporter\", domain=~\"$domain\"}[2m])) * on(instance) libvirt_domain_info_meta{job=\"libvirt_exporter\", uuid=~\"$uuid\"}",
-                      "format": "time_series",
-                      "instant": false,
-                      "interval": "",
-                      "legendFormat": "__auto",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "A"
-                }
-              }
-            ],
-            "queryOptions": {},
-            "transformations": []
-          }
-        },
-        "description": "",
-        "id": 20,
-        "links": [],
-        "title": "Host CPU Utilisation",
-        "vizConfig": {
-          "group": "timeseries",
-          "kind": "VizConfig",
-          "spec": {
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "palette-classic"
-                },
-                "custom": {
-                  "axisBorderShow": false,
-                  "axisCenteredZero": false,
-                  "axisColorMode": "text",
-                  "axisLabel": "",
-                  "axisPlacement": "auto",
-                  "barAlignment": 0,
-                  "barWidthFactor": 0.6,
-                  "drawStyle": "line",
-                  "fillOpacity": 0,
-                  "gradientMode": "none",
-                  "hideFrom": {
-                    "legend": false,
-                    "tooltip": false,
-                    "viz": false
-                  },
-                  "insertNulls": false,
-                  "lineInterpolation": "linear",
-                  "lineWidth": 1,
-                  "pointSize": 5,
-                  "scaleDistribution": {
-                    "type": "linear"
-                  },
-                  "showPoints": "auto",
-                  "showValues": false,
-                  "spanNulls": false,
-                  "stacking": {
-                    "group": "A",
-                    "mode": "none"
-                  },
-                  "thresholdsStyle": {
-                    "mode": "off"
-                  }
-                },
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "none"
-              },
-              "overrides": []
-            },
-            "options": {
-              "annotations": {
-                "clustering": -1,
-                "multiLane": false
-              },
-              "legend": {
-                "calcs": [],
-                "displayMode": "list",
-                "placement": "bottom",
-                "showLegend": true
-              },
-              "tooltip": {
-                "hideZeros": false,
-                "mode": "single",
-                "sort": "none"
-              }
-            }
-          },
-          "version": "13.0.1+security-01"
-        }
-      }
-    },
-    "panel-21": {
-      "kind": "Panel",
-      "spec": {
-        "data": {
-          "kind": "QueryGroup",
-          "spec": {
-            "queries": [
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "expr": "ipmi_dcmi_power_consumption_watts{instance=~\"$Hypervisor\"}",
-                      "instant": false,
-                      "legendFormat": "HypervisorPower{{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "Hypervisor Power"
-                }
-              },
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "exemplar": false,
-                      "expr": "irate(libvirt_domain_info_cpu_time_seconds_total{job=\"libvirt_exporter\", domain=\"$domain\"}[5m])",
-                      "instant": false,
-                      "legendFormat": "VM CPU Usage{{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "VM CPU Usage"
-                }
-              },
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "expr": "sum by(instance) (irate(libvirt_domain_info_cpu_time_seconds_total{job=\"libvirt_exporter\", instance=~\"$Hypervisor\"}[5m]))",
-                      "instant": false,
-                      "legendFormat": "Hypervisor CPU Usage {{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "Hypervisor CPU Usage"
-                }
-              }
-            ],
-            "queryOptions": {},
-            "transformations": [
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "VM CPU Usage"
-                        }
-                      },
-                      "operator": "/",
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Hypervisor CPU Usage "
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    }
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "alias": "VM Power (W)",
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "HypervisorPower"
-                        }
-                      },
-                      "operator": "*",
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "VM CPU Usage / Hypervisor CPU Usage "
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    },
-                    "replaceFields": false
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "alias": "pue",
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "VM Power (W)"
-                        }
-                      },
-                      "operator": "*",
-                      "right": {
-                        "fixed": "1.3"
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    },
-                    "replaceFields": true
-                  }
-                }
-              }
-            ]
-          }
-        },
-        "description": "VM Power = (VM_CPU_core / Host_CPU_core) * [Host_Min_Watts + VM_Utilisation * (Host_Max_Watts - Host_Min_Watts)]",
-        "id": 21,
-        "links": [],
-        "title": "⚡VM Average Power (W)",
-        "vizConfig": {
-          "group": "stat",
-          "kind": "VizConfig",
-          "spec": {
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "thresholds"
-                },
-                "fieldMinMax": false,
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "watt"
-              },
-              "overrides": []
-            },
-            "options": {
-              "colorMode": "none",
-              "graphMode": "none",
-              "justifyMode": "auto",
-              "orientation": "auto",
-              "percentChangeColorMode": "standard",
-              "reduceOptions": {
-                "calcs": [
-                  "mean"
-                ],
-                "fields": "",
-                "values": false
-              },
-              "showPercentChange": false,
-              "textMode": "auto",
-              "wideLayout": true
-            }
-          },
-          "version": "13.0.2"
-        }
-      }
-    },
-    "panel-22": {
-      "kind": "Panel",
-      "spec": {
-        "data": {
-          "kind": "QueryGroup",
-          "spec": {
-            "queries": [
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "expr": "ipmi_dcmi_power_consumption_watts{instance=~\"$Hypervisor\"}",
-                      "instant": false,
-                      "legendFormat": "HypervisorPower{{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "Hypervisor Power"
-                }
-              },
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "exemplar": false,
-                      "expr": "irate(libvirt_domain_info_cpu_time_seconds_total{job=\"libvirt_exporter\", domain=\"$domain\"}[5m])",
-                      "instant": false,
-                      "legendFormat": "VM CPU Usage{{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "VM CPU Usage"
-                }
-              },
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "expr": "sum by(instance) (irate(libvirt_domain_info_cpu_time_seconds_total{job=\"libvirt_exporter\", instance=~\"$Hypervisor\"}[5m]))",
-                      "instant": false,
-                      "legendFormat": "Hypervisor CPU Usage {{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "Hypervisor CPU Usage"
-                }
-              },
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "code",
-                      "expr": "$__range_s / 3600",
-                      "instant": false,
-                      "legendFormat": "Duration(hour){{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "Duration (hour)"
-                }
-              }
-            ],
-            "queryOptions": {},
-            "transformations": [
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "VM CPU Usage"
-                        }
-                      },
-                      "operator": "/",
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Hypervisor CPU Usage "
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    }
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "alias": "VM Power (W)",
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "HypervisorPower"
-                        }
-                      },
-                      "operator": "*",
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "VM CPU Usage / Hypervisor CPU Usage "
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    },
-                    "replaceFields": false
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "VM Power (W)"
-                        }
-                      },
-                      "operator": "*",
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Duration(hour)"
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    },
-                    "replaceFields": true
-                  }
-                }
-              }
-            ]
-          }
-        },
-        "description": "Equation: <br>\nVM Power ≈ Hypervisor Power × (VM CPU Usage / Hypervisor CPU Usage)",
-        "id": 22,
-        "links": [],
-        "title": "⚡VM Total Energy Used (kWh)",
-        "vizConfig": {
-          "group": "stat",
-          "kind": "VizConfig",
-          "spec": {
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "thresholds"
-                },
-                "fieldMinMax": false,
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "watth"
-              },
-              "overrides": []
-            },
-            "options": {
-              "colorMode": "none",
-              "graphMode": "none",
-              "justifyMode": "auto",
-              "orientation": "auto",
-              "percentChangeColorMode": "standard",
-              "reduceOptions": {
-                "calcs": [
-                  "mean"
-                ],
-                "fields": "",
-                "values": false
-              },
-              "showPercentChange": false,
-              "textMode": "auto",
-              "wideLayout": true
-            }
-          },
-          "version": "13.0.2"
-        }
-      }
-    },
-    "panel-23": {
-      "kind": "Panel",
-      "spec": {
-        "data": {
-          "kind": "QueryGroup",
-          "spec": {
-            "queries": [
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "expr": "ipmi_dcmi_power_consumption_watts{instance=~\"$Hypervisor\"}",
-                      "instant": false,
-                      "legendFormat": "HypervisorPower{{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "Hypervisor Power"
-                }
-              },
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "exemplar": false,
-                      "expr": "irate(libvirt_domain_info_cpu_time_seconds_total{job=\"libvirt_exporter\", domain=\"$domain\"}[5m])",
-                      "instant": false,
-                      "legendFormat": "VM CPU Usage{{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "VM CPU Usage"
-                }
-              },
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "expr": "sum by(instance) (irate(libvirt_domain_info_cpu_time_seconds_total{job=\"libvirt_exporter\", instance=~\"$Hypervisor\"}[5m]))",
-                      "instant": false,
-                      "legendFormat": "Hypervisor CPU Usage {{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "Hypervisor CPU Usage"
-                }
-              },
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "code",
-                      "expr": "$__range_s / 3600",
-                      "instant": false,
-                      "legendFormat": "Duration(hour){{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "Duration (hour)"
-                }
-              }
-            ],
-            "queryOptions": {},
-            "transformations": [
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "VM CPU Usage"
-                        }
-                      },
-                      "operator": "/",
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Hypervisor CPU Usage "
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    }
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "alias": "VM Power (W)",
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "HypervisorPower"
-                        }
-                      },
-                      "operator": "*",
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "VM CPU Usage / Hypervisor CPU Usage "
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    },
-                    "replaceFields": false
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "alias": "Total VM Energy (Wh)",
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "VM Power (W)"
-                        }
-                      },
-                      "operator": "*",
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Duration(hour)"
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    },
-                    "replaceFields": false
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "alias": "Total VM Energy (kWh)",
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Total VM Energy (Wh)"
-                        }
-                      },
-                      "operator": "/",
-                      "right": {
-                        "fixed": "1000"
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    }
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "alias": "pue",
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Total VM Energy (kWh)"
-                        }
-                      },
-                      "operator": "*",
-                      "right": {
-                        "fixed": "1.3"
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    }
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "alias": "gco2",
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "pue"
-                        }
-                      },
-                      "operator": "*",
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "$carbon_intensity"
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "include": [
-                        "Total VM Energy (kWh) * 1.3"
-                      ],
-                      "reducer": "sum"
-                    },
-                    "replaceFields": true
-                  }
-                }
-              }
-            ]
-          }
-        },
-        "description": "UK average carbon intensity in 2025 is 126 gCO2/kWh. <br>\nSource: <br>\nhttps://www.carbonbrief.org/analysis-uk-renewables-enjoy-record-year-in-2025-but-gas-power-still-rises/ <br>\nhttps://www.energydashboard.co.uk/insights/2025-review",
-        "id": 23,
-        "links": [],
-        "title": "🌍 Total Carbon Emission (gCO2)",
-        "vizConfig": {
-          "group": "stat",
-          "kind": "VizConfig",
-          "spec": {
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "thresholds"
-                },
-                "fieldMinMax": false,
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "massg"
-              },
-              "overrides": []
-            },
-            "options": {
-              "colorMode": "none",
-              "graphMode": "none",
-              "justifyMode": "auto",
-              "orientation": "auto",
-              "percentChangeColorMode": "standard",
-              "reduceOptions": {
-                "calcs": [
-                  "mean"
-                ],
-                "fields": "",
-                "values": false
-              },
-              "showPercentChange": false,
-              "textMode": "auto",
-              "wideLayout": true
-            }
-          },
-          "version": "13.0.2"
-        }
-      }
-    },
-    "panel-24": {
-      "kind": "Panel",
-      "spec": {
-        "data": {
-          "kind": "QueryGroup",
-          "spec": {
-            "queries": [
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "expr": "ipmi_dcmi_power_consumption_watts{instance=~\"$Hypervisor\"}",
-                      "instant": false,
-                      "legendFormat": "HypervisorPower{{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "Hypervisor Power"
-                }
-              },
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "exemplar": false,
-                      "expr": "irate(libvirt_domain_info_cpu_time_seconds_total{job=\"libvirt_exporter\", domain=\"$domain\"}[5m])",
-                      "instant": false,
-                      "legendFormat": "VM CPU Usage{{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "VM CPU Usage"
-                }
-              },
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "expr": "sum by(instance) (irate(libvirt_domain_info_cpu_time_seconds_total{job=\"libvirt_exporter\", instance=~\"$Hypervisor\"}[5m]))",
-                      "instant": false,
-                      "legendFormat": "Hypervisor CPU Usage {{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "Hypervisor CPU Usage"
-                }
-              }
-            ],
-            "queryOptions": {},
-            "transformations": [
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "VM CPU Usage"
-                        }
-                      },
-                      "operator": "/",
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Hypervisor CPU Usage "
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    }
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "alias": "VM Power (W)",
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "HypervisorPower"
-                        }
-                      },
-                      "operator": "*",
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "VM CPU Usage / Hypervisor CPU Usage "
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    },
-                    "replaceFields": true
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "alias": "VM Power (kW)",
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "VM Power (W)"
-                        }
-                      },
-                      "operator": "/",
-                      "right": {
-                        "fixed": "1000"
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    }
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "alias": "pue",
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "VM Power (kW)"
-                        }
-                      },
-                      "operator": "*",
-                      "right": {
-                        "fixed": "1.3"
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    },
-                    "replaceFields": false
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "pue"
-                        }
-                      },
-                      "operator": "*",
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "$carbon_intensity"
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    },
-                    "replaceFields": true
-                  }
-                }
-              }
-            ]
-          }
-        },
-        "description": "",
-        "id": 24,
-        "links": [],
-        "title": "🌍 Carbon Emission of VM per Hour (gCO2)",
-        "vizConfig": {
-          "group": "stat",
-          "kind": "VizConfig",
-          "spec": {
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "thresholds"
-                },
-                "fieldMinMax": false,
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "massg"
-              },
-              "overrides": []
-            },
-            "options": {
-              "colorMode": "none",
-              "graphMode": "none",
-              "justifyMode": "auto",
-              "orientation": "auto",
-              "percentChangeColorMode": "standard",
-              "reduceOptions": {
-                "calcs": [
-                  "mean"
-                ],
-                "fields": "",
-                "values": false
-              },
-              "showPercentChange": false,
-              "textMode": "auto",
-              "wideLayout": true
-            }
-          },
-          "version": "13.0.2"
-        }
-      }
-    },
-    "panel-25": {
-      "kind": "Panel",
-      "spec": {
-        "data": {
-          "kind": "QueryGroup",
-          "spec": {
-            "queries": [
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "expr": "ipmi_dcmi_power_consumption_watts{instance=~\"$Hypervisor\"}",
-                      "instant": false,
-                      "legendFormat": "HypervisorPower{{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "Hypervisor Power"
-                }
-              },
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "exemplar": false,
-                      "expr": "irate(libvirt_domain_info_cpu_time_seconds_total{job=\"libvirt_exporter\", domain=\"$domain\"}[5m])",
-                      "instant": false,
-                      "legendFormat": "VM CPU Usage{{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "VM CPU Usage"
-                }
-              },
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "expr": "sum by(instance) (irate(libvirt_domain_info_cpu_time_seconds_total{job=\"libvirt_exporter\", instance=~\"$Hypervisor\"}[5m]))",
-                      "instant": false,
-                      "legendFormat": "Hypervisor CPU Usage {{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "Hypervisor CPU Usage"
-                }
-              },
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "code",
-                      "expr": "$__range_s / 3600",
-                      "instant": false,
-                      "legendFormat": "Duration(hour){{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "Duration (hour)"
-                }
-              }
-            ],
-            "queryOptions": {},
-            "transformations": [
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "VM CPU Usage"
-                        }
-                      },
-                      "operator": "/",
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Hypervisor CPU Usage "
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    }
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "alias": "VM Power (W)",
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "HypervisorPower"
-                        }
-                      },
-                      "operator": "*",
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "VM CPU Usage / Hypervisor CPU Usage "
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    },
-                    "replaceFields": false
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "alias": "Total VM Energy (Wh)",
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "VM Power (W)"
-                        }
-                      },
-                      "operator": "*",
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Duration(hour)"
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    },
-                    "replaceFields": false
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "alias": "Total VM Energy (kWh)",
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Total VM Energy (Wh)"
-                        }
-                      },
-                      "operator": "/",
-                      "right": {
-                        "fixed": "1000"
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    }
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "alias": "pue",
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Total VM Energy (kWh)"
-                        }
-                      },
-                      "operator": "*",
-                      "right": {
-                        "fixed": "1.3"
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    },
-                    "replaceFields": false
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "alias": "£",
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "pue"
-                        }
-                      },
-                      "operator": "*",
-                      "right": {
-                        "fixed": "0.21"
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    },
-                    "replaceFields": true
-                  }
-                }
-              }
-            ]
-          }
-        },
-        "description": "As of 17th March 2026 <br>\nAverage electricity cost report by HPC Operation Costing Report is £0.21 per kWh. <br>\nElectricity Cost = Total Energy * 0.21 <br>\nSource: <br>\nhttp://cacti-master-virt.di.stfc.ac.uk/Information/CostingForm.php",
-        "id": 25,
-        "links": [],
-        "title": "⚡ VM Energy Cost",
-        "vizConfig": {
-          "group": "stat",
-          "kind": "VizConfig",
-          "spec": {
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "thresholds"
-                },
-                "fieldMinMax": false,
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "currencyGBP"
-              },
-              "overrides": []
-            },
-            "options": {
-              "colorMode": "none",
-              "graphMode": "none",
-              "justifyMode": "auto",
-              "orientation": "auto",
-              "percentChangeColorMode": "standard",
-              "reduceOptions": {
-                "calcs": [
-                  "mean"
-                ],
-                "fields": "",
-                "values": false
-              },
-              "showPercentChange": false,
-              "textMode": "auto",
-              "wideLayout": true
-            }
-          },
-          "version": "13.0.2"
-        }
-      }
-    },
-    "panel-26": {
-      "kind": "Panel",
-      "spec": {
-        "data": {
-          "kind": "QueryGroup",
-          "spec": {
-            "queries": [
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "expr": "ipmi_dcmi_power_consumption_watts{instance=~\"$Hypervisor\"}",
-                      "instant": false,
-                      "legendFormat": "HypervisorPower{{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "Hypervisor Power"
-                }
-              },
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "exemplar": false,
-                      "expr": "irate(libvirt_domain_info_cpu_time_seconds_total{job=\"libvirt_exporter\", domain=\"$domain\"}[5m])",
-                      "instant": false,
-                      "legendFormat": "VM CPU Usage{{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "VM CPU Usage"
-                }
-              },
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "expr": "sum by(instance) (irate(libvirt_domain_info_cpu_time_seconds_total{job=\"libvirt_exporter\", instance=~\"$Hypervisor\"}[5m]))",
-                      "instant": false,
-                      "legendFormat": "Hypervisor CPU Usage {{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "Hypervisor CPU Usage"
-                }
-              },
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "code",
-                      "expr": "$__range_s / 3600",
-                      "instant": false,
-                      "legendFormat": "Duration(hour){{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "Duration (hour)"
-                }
-              }
-            ],
-            "queryOptions": {},
-            "transformations": [
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "VM CPU Usage"
-                        }
-                      },
-                      "operator": "/",
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Hypervisor CPU Usage "
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    }
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "alias": "VM Power (W)",
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "HypervisorPower"
-                        }
-                      },
-                      "operator": "*",
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "VM CPU Usage / Hypervisor CPU Usage "
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    },
-                    "replaceFields": false
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "alias": "Total VM Energy (Wh)",
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "VM Power (W)"
-                        }
-                      },
-                      "operator": "*",
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Duration(hour)"
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    },
-                    "replaceFields": false
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "alias": "Total VM Energy (kWh)",
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Total VM Energy (Wh)"
-                        }
-                      },
-                      "operator": "/",
-                      "right": {
-                        "fixed": "1000"
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    }
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "alias": "pue",
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Total VM Energy (kWh)"
-                        }
-                      },
-                      "operator": "*",
-                      "right": {
-                        "fixed": "1.3"
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    },
-                    "replaceFields": false
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "alias": "gCO2",
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "pue"
-                        }
-                      },
-                      "operator": "*",
-                      "right": {
-                        "fixed": "126"
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    }
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "alias": "Car",
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "gCO2"
-                        }
-                      },
-                      "operator": "/",
-                      "right": {
-                        "fixed": "7150"
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    },
-                    "replaceFields": true
-                  }
-                }
-              }
-            ]
-          }
-        },
-        "description": "Petrol cars had 143 gCO2/km\n=> 7150 gCO2 per hour driving (assuming 50km/h or 30mph)\nSource: 2022 UK GOV (https://www.gov.uk/government/statistics/vehicle-licensing-statistics-2022/vehicle-licensing-statistics-2022#carbon-co2-emissions-for-new-vehicle-registrations)",
-        "id": 26,
-        "links": [],
-        "title": "🚗 Driving a Petrol Car for",
-        "vizConfig": {
-          "group": "stat",
-          "kind": "VizConfig",
-          "spec": {
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "thresholds"
-                },
-                "decimals": 2,
-                "fieldMinMax": false,
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "h"
-              },
-              "overrides": []
-            },
-            "options": {
-              "colorMode": "none",
-              "graphMode": "none",
-              "justifyMode": "auto",
-              "orientation": "auto",
-              "percentChangeColorMode": "standard",
-              "reduceOptions": {
-                "calcs": [
-                  "mean"
-                ],
-                "fields": "",
-                "values": false
-              },
-              "showPercentChange": false,
-              "textMode": "auto",
-              "wideLayout": true
-            }
-          },
-          "version": "13.0.2"
-        }
-      }
-    },
-    "panel-27": {
-      "kind": "Panel",
-      "spec": {
-        "data": {
-          "kind": "QueryGroup",
-          "spec": {
-            "queries": [
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "expr": "ipmi_dcmi_power_consumption_watts{instance=~\"$Hypervisor\"}",
-                      "instant": false,
-                      "legendFormat": "HypervisorPower{{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "Hypervisor Power"
-                }
-              },
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "exemplar": false,
-                      "expr": "irate(libvirt_domain_info_cpu_time_seconds_total{job=\"libvirt_exporter\", domain=\"$domain\"}[5m])",
-                      "instant": false,
-                      "legendFormat": "VM CPU Usage{{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "VM CPU Usage"
-                }
-              },
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "expr": "sum by(instance) (irate(libvirt_domain_info_cpu_time_seconds_total{job=\"libvirt_exporter\", instance=~\"$Hypervisor\"}[5m]))",
-                      "instant": false,
-                      "legendFormat": "Hypervisor CPU Usage {{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "Hypervisor CPU Usage"
-                }
-              },
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "code",
-                      "expr": "$__range_s / 3600",
-                      "instant": false,
-                      "legendFormat": "Duration(hour){{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "Duration (hour)"
-                }
-              }
-            ],
-            "queryOptions": {},
-            "transformations": [
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "VM CPU Usage"
-                        }
-                      },
-                      "operator": "/",
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Hypervisor CPU Usage "
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    }
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "alias": "VM Power (W)",
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "HypervisorPower"
-                        }
-                      },
-                      "operator": "*",
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "VM CPU Usage / Hypervisor CPU Usage "
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    },
-                    "replaceFields": false
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "alias": "Total VM Energy (Wh)",
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "VM Power (W)"
-                        }
-                      },
-                      "operator": "*",
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Duration(hour)"
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    },
-                    "replaceFields": false
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "alias": "Total VM Energy (kWh)",
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Total VM Energy (Wh)"
-                        }
-                      },
-                      "operator": "/",
-                      "right": {
-                        "fixed": "1000"
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    }
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "alias": "pue",
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Total VM Energy (kWh)"
-                        }
-                      },
-                      "operator": "*",
-                      "right": {
-                        "fixed": "1.3"
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    },
-                    "replaceFields": false
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "alias": "gCO2",
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "pue"
-                        }
-                      },
-                      "operator": "*",
-                      "right": {
-                        "fixed": "126"
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    }
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "alias": "Tree",
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "gCO2"
-                        }
-                      },
-                      "operator": "/",
-                      "right": {
-                        "fixed": "25000"
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    },
-                    "replaceFields": true
-                  }
-                }
-              }
-            ]
-          }
-        },
-        "description": "A tree absorbs approximately 25kg of CO2 per year. <br>\nSource: <br>\nhttps://ecotree.green/en/how-much-co2-does-a-tree-absorb",
-        "id": 27,
-        "links": [],
-        "title": "🌳 Carbon absorbed in 1 year by",
-        "vizConfig": {
-          "group": "stat",
-          "kind": "VizConfig",
-          "spec": {
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "thresholds"
-                },
-                "decimals": 2,
-                "fieldMinMax": false,
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "Trees"
-              },
-              "overrides": []
-            },
-            "options": {
-              "colorMode": "none",
-              "graphMode": "none",
-              "justifyMode": "auto",
-              "orientation": "auto",
-              "percentChangeColorMode": "standard",
-              "reduceOptions": {
-                "calcs": [
-                  "mean"
-                ],
-                "fields": "",
-                "values": false
-              },
-              "showPercentChange": false,
-              "textMode": "auto",
-              "wideLayout": true
-            }
-          },
-          "version": "13.0.2"
-        }
-      }
-    },
-    "panel-4": {
-      "kind": "Panel",
-      "spec": {
-        "data": {
-          "kind": "QueryGroup",
-          "spec": {
-            "queries": [
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "code",
-                      "expr": "$__range_s / 3600",
-                      "instant": false,
-                      "legendFormat": "__auto",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "A"
-                }
-              }
-            ],
-            "queryOptions": {},
-            "transformations": []
-          }
-        },
-        "description": "",
-        "id": 4,
-        "links": [],
-        "title": "Duration",
-        "vizConfig": {
-          "group": "stat",
-          "kind": "VizConfig",
-          "spec": {
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "palette-classic"
-                },
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "h"
-              },
-              "overrides": []
-            },
-            "options": {
-              "colorMode": "value",
-              "graphMode": "none",
-              "justifyMode": "auto",
-              "orientation": "auto",
-              "percentChangeColorMode": "standard",
-              "reduceOptions": {
-                "calcs": [
-                  "lastNotNull"
-                ],
-                "fields": "",
-                "values": false
-              },
-              "showPercentChange": false,
-              "textMode": "auto",
-              "wideLayout": true
-            }
-          },
-          "version": "13.0.2"
-        }
-      }
-    },
-    "panel-8": {
-      "kind": "Panel",
-      "spec": {
-        "data": {
-          "kind": "QueryGroup",
-          "spec": {
-            "queries": [],
-            "queryOptions": {},
-            "transformations": []
-          }
-        },
-        "description": "",
-        "id": 8,
-        "links": [],
-        "title": "",
-        "vizConfig": {
-          "group": "text",
-          "kind": "VizConfig",
-          "spec": {
-            "fieldConfig": {
-              "defaults": {},
-              "overrides": []
-            },
-            "options": {
-              "code": {
-                "language": "plaintext",
-                "showLineNumbers": false,
-                "showMiniMap": false
-              },
-              "content": "# ⚡Virtual Machine Power & Carbon Emissions Dashboard Method 1\nThis dashboard estimates the **power consumption** and **carbon emissions** of an OpenStack Virtual Machine (VM) over a selected time period.<br>\nThe calculation is based on the **VM CPU usage relative to the total CPU usage of the hypervisor host.**\n> ⚠️ The results represent an **approximation**, not an exact measurement of VM energy usage.<br>\n> ⚠️ This dashboard supports Compute (CPU) flavours only.<br>\n`GPU flavours are not supported and may produce incorrect estimates.`\n\n## 🧭 How to Use This Dashboard\n\n1. **Select your VM Instance Name:**<br>\nUse the Instance Name dropdown at the top of the dashboard to select your VM.<br>\n2. **Handle duplicate VM names (if applicable):**<br>\n-If multiple VMs share the same name:<br>\n-Go to: https://openstack.stfc.ac.uk<br>\n-Navigate to: Project → Instances<br>\n-Find the correct VM and copy its Instance ID (UUID)<br>\n-In Grafana, after selecting the instance name, choose the corresponding VM UUID from the UUID variable dropdown<br>\n5. **Select the time range:**<br>\nChoose the time period you want to analyse using the time picker.<br>\n6. **View the Results, the dashboard will display:**<br>\nEstimated VM power consumption<br>\nEstimated carbon emissions\n\n## 🧮 Calculation Method\nThe VM power consumption is estimated using proportional CPU utilisation:<br>\n      `VM Power ≈ Hypervisor Power × (VM CPU Usage / Hypervisor CPU Usage)`<br>\nThis method attributes a share of the physical server's power consumption to each VM based on its relative CPU activity.\n\n\n## ⚠️ Important Limitations\nThe VM power attribution is calculated only from CPU resources and does not include:<br>\n- Memory (RAM) usage\n- Disk storage and I/O activity\n- Network traffic\n- GPU or accelerator usage<br>\n\nWorkloads that rely heavily on these resources may therefore have their actual energy usage under- or over-estimated.<br>\nTherefore, this dashboard currently supports only Compute (CPU) flavours.<br>\nGPU flavours are not supported and will not produce accurate power or carbon estimates.\n## 🌱 Purpose of This Dashboard:\nThis dashboard helps users:\n- Understand the energy footprint of their virtual machines.\n- Estimate carbon emissions of workloads\n- Support sustainability and energy awareness in using STFC Cloud",
-              "mode": "markdown"
-            }
-          },
-          "version": "13.0.2"
-        }
-      }
-    }
-  },
-  "layout": {
-    "kind": "RowsLayout",
-    "spec": {
-      "rows": [
-        {
-          "kind": "RowsLayoutRow",
-          "spec": {
-            "collapse": false,
-            "layout": {
-              "kind": "GridLayout",
-              "spec": {
-                "items": [
-                  {
-                    "kind": "GridLayoutItem",
-                    "spec": {
-                      "element": {
-                        "kind": "ElementReference",
-                        "name": "panel-8"
-                      },
-                      "height": 18,
-                      "width": 18,
-                      "x": 0,
-                      "y": 0
-                    }
-                  },
-                  {
-                    "kind": "GridLayoutItem",
-                    "spec": {
-                      "element": {
-                        "kind": "ElementReference",
-                        "name": "panel-4"
-                      },
-                      "height": 3,
-                      "width": 6,
-                      "x": 18,
-                      "y": 0
-                    }
-                  },
-                  {
-                    "kind": "GridLayoutItem",
-                    "spec": {
-                      "element": {
-                        "kind": "ElementReference",
-                        "name": "panel-23"
-                      },
-                      "height": 3,
-                      "width": 6,
-                      "x": 18,
-                      "y": 3
-                    }
-                  },
-                  {
-                    "kind": "GridLayoutItem",
-                    "spec": {
-                      "element": {
-                        "kind": "ElementReference",
-                        "name": "panel-24"
-                      },
-                      "height": 3,
-                      "width": 6,
-                      "x": 18,
-                      "y": 6
-                    }
-                  },
-                  {
-                    "kind": "GridLayoutItem",
-                    "spec": {
-                      "element": {
-                        "kind": "ElementReference",
-                        "name": "panel-21"
-                      },
-                      "height": 3,
-                      "width": 6,
-                      "x": 18,
-                      "y": 9
-                    }
-                  },
-                  {
-                    "kind": "GridLayoutItem",
-                    "spec": {
-                      "element": {
-                        "kind": "ElementReference",
-                        "name": "panel-22"
-                      },
-                      "height": 3,
-                      "width": 6,
-                      "x": 18,
-                      "y": 12
-                    }
-                  },
-                  {
-                    "kind": "GridLayoutItem",
-                    "spec": {
-                      "element": {
-                        "kind": "ElementReference",
-                        "name": "panel-25"
-                      },
-                      "height": 3,
-                      "width": 6,
-                      "x": 18,
-                      "y": 15
-                    }
-                  },
-                  {
-                    "kind": "GridLayoutItem",
-                    "spec": {
-                      "element": {
-                        "kind": "ElementReference",
-                        "name": "panel-26"
-                      },
-                      "height": 4,
-                      "width": 6,
-                      "x": 0,
-                      "y": 18
-                    }
-                  },
-                  {
-                    "kind": "GridLayoutItem",
-                    "spec": {
-                      "element": {
-                        "kind": "ElementReference",
-                        "name": "panel-27"
-                      },
-                      "height": 4,
-                      "width": 6,
-                      "x": 6,
-                      "y": 18
-                    }
-                  },
-                  {
-                    "kind": "GridLayoutItem",
-                    "spec": {
-                      "element": {
-                        "kind": "ElementReference",
-                        "name": "panel-1"
-                      },
-                      "height": 8,
-                      "width": 24,
-                      "x": 0,
-                      "y": 22
-                    }
-                  }
-                ]
-              }
-            },
-            "title": "Main"
-          }
-        },
-        {
-          "kind": "RowsLayoutRow",
-          "spec": {
-            "collapse": false,
-            "layout": {
-              "kind": "GridLayout",
-              "spec": {
-                "items": [
-                  {
-                    "kind": "GridLayoutItem",
-                    "spec": {
-                      "element": {
-                        "kind": "ElementReference",
-                        "name": "panel-11"
-                      },
-                      "height": 4,
-                      "width": 6,
-                      "x": 0,
-                      "y": 0
-                    }
-                  },
-                  {
-                    "kind": "GridLayoutItem",
-                    "spec": {
-                      "element": {
-                        "kind": "ElementReference",
-                        "name": "panel-12"
-                      },
-                      "height": 4,
-                      "width": 4,
-                      "x": 6,
-                      "y": 0
-                    }
-                  },
-                  {
-                    "kind": "GridLayoutItem",
-                    "spec": {
-                      "element": {
-                        "kind": "ElementReference",
-                        "name": "panel-14"
-                      },
-                      "height": 4,
-                      "width": 6,
-                      "x": 10,
-                      "y": 0
-                    }
-                  },
-                  {
-                    "kind": "GridLayoutItem",
-                    "spec": {
-                      "element": {
-                        "kind": "ElementReference",
-                        "name": "panel-13"
-                      },
-                      "height": 4,
-                      "width": 6,
-                      "x": 16,
-                      "y": 0
-                    }
-                  },
-                  {
-                    "kind": "GridLayoutItem",
-                    "spec": {
-                      "element": {
-                        "kind": "ElementReference",
-                        "name": "panel-15"
-                      },
-                      "height": 6,
-                      "width": 3,
-                      "x": 0,
-                      "y": 4
-                    }
-                  },
-                  {
-                    "kind": "GridLayoutItem",
-                    "spec": {
-                      "element": {
-                        "kind": "ElementReference",
-                        "name": "panel-16"
-                      },
-                      "height": 6,
-                      "width": 3,
-                      "x": 3,
-                      "y": 4
-                    }
-                  },
-                  {
-                    "kind": "GridLayoutItem",
-                    "spec": {
-                      "element": {
-                        "kind": "ElementReference",
-                        "name": "panel-17"
-                      },
-                      "height": 6,
-                      "width": 4,
-                      "x": 6,
-                      "y": 4
-                    }
-                  },
-                  {
-                    "kind": "GridLayoutItem",
-                    "spec": {
-                      "element": {
-                        "kind": "ElementReference",
-                        "name": "panel-18"
-                      },
-                      "height": 6,
-                      "width": 4,
-                      "x": 10,
-                      "y": 4
-                    }
-                  },
-                  {
-                    "kind": "GridLayoutItem",
-                    "spec": {
-                      "element": {
-                        "kind": "ElementReference",
-                        "name": "panel-19"
-                      },
-                      "height": 6,
-                      "width": 4,
-                      "x": 14,
-                      "y": 4
-                    }
-                  },
-                  {
-                    "kind": "GridLayoutItem",
-                    "spec": {
-                      "element": {
-                        "kind": "ElementReference",
-                        "name": "panel-20"
-                      },
-                      "height": 6,
-                      "width": 4,
-                      "x": 18,
-                      "y": 4
-                    }
-                  }
-                ]
-              }
-            },
-            "title": "Host & VM Metrics"
-          }
-        }
-      ]
-    }
-  },
-  "links": [],
-  "liveNow": false,
-  "preferences": {
-    "layout": {
-      "kind": "GridLayout",
-      "spec": {
-        "items": []
-      }
-    }
-  },
   "preload": false,
-  "tags": [],
-  "timeSettings": {
-    "autoRefresh": "",
-    "autoRefreshIntervals": [
+  "refresh": "",
+  "schemaVersion": 42,
+  "templating": {
+    "list": [
+      {
+        "allowCustomValue": true,
+        "current": {
+          "text": "RemoteWritePrometheus",
+          "value": "remote_write_prometheus"
+        },
+        "description": "The prometheus datasource used for queries.",
+        "hide": 0,
+        "includeAll": false,
+        "label": "datasource",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "RemoteWritePrometheus",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "allowCustomValue": true,
+        "current": {
+          "text": "AI4S",
+          "value": "AI4S"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "remote_write_prometheus"
+        },
+        "definition": "label_values(libvirt_domain_info_meta,instance_name)",
+        "description": "Name of your Virtual Machine instance as created on STFC Cloud OpenStack",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Virtual Machine Name",
+        "multi": false,
+        "name": "instance_name",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(libvirt_domain_info_meta,instance_name)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "regexApplyTo": "value",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "allowCustomValue": true,
+        "current": {
+          "text": "c3d23176-236b-4165-8aa4-33232ce21118",
+          "value": "c3d23176-236b-4165-8aa4-33232ce21118"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "remote_write_prometheus"
+        },
+        "definition": "label_values(libvirt_domain_info_meta{job=\"libvirt_exporter\", instance_name=~\"$instance_name\"},uuid)",
+        "description": "Virtual Machine UUID from STFC Cloud OpenStack",
+        "hide": 0,
+        "includeAll": false,
+        "label": "VM uuid",
+        "multi": false,
+        "name": "uuid",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(libvirt_domain_info_meta{job=\"libvirt_exporter\", instance_name=~\"$instance_name\"},uuid)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "regexApplyTo": "value",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "allowCustomValue": true,
+        "current": {
+          "text": "hv-a100x8-6.nubes.rl.ac.uk",
+          "value": "hv-a100x8-6.nubes.rl.ac.uk"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "remote_write_prometheus"
+        },
+        "definition": "label_values(libvirt_domain_info_meta{job=\"libvirt_exporter\", uuid=~\"$uuid\"},instance)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Hypervisor",
+        "multi": false,
+        "name": "Hypervisor",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(libvirt_domain_info_meta{job=\"libvirt_exporter\", uuid=~\"$uuid\"},instance)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "regexApplyTo": "value",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allowCustomValue": false,
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "remote_write_prometheus"
+        },
+        "definition": "label_values(libvirt_domain_info_meta{job=\"libvirt_exporter\", instance_name=~\"$instance_name\"},domain)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Domain",
+        "multi": false,
+        "name": "domain",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(libvirt_domain_info_meta{job=\"libvirt_exporter\", instance_name=~\"$instance_name\"},domain)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "regexApplyTo": "value",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {
+          "text": "126",
+          "value": "126"
+        },
+        "description": "",
+        "hide": 2,
+        "label": "",
+        "name": "carbon_intensity",
+        "query": "126",
+        "skipUrlSync": true,
+        "type": "constant"
+      },
+      {
+        "current": {
+          "text": "1.3",
+          "value": "1.3"
+        },
+        "hide": 2,
+        "name": "pue",
+        "query": "1.3",
+        "skipUrlSync": true,
+        "type": "constant"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-12h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
       "5s",
       "10s",
       "30s",
@@ -3777,205 +2984,11 @@
       "1h",
       "2h",
       "1d"
-    ],
-    "fiscalYearStartMonth": 0,
-    "from": "now-12h",
-    "hideTimepicker": false,
-    "timezone": "browser",
-    "to": "now"
+    ]
   },
+  "timezone": "browser",
   "title": "VM Power & Carbon Method 1",
-  "variables": [
-    {
-      "kind": "DatasourceVariable",
-      "spec": {
-        "allowCustomValue": true,
-        "current": {
-          "text": "RemoteWritePrometheus",
-          "value": "remote_write_prometheus"
-        },
-        "description": "The prometheus datasource used for queries.",
-        "hide": "dontHide",
-        "includeAll": false,
-        "label": "datasource",
-        "multi": false,
-        "name": "datasource",
-        "options": [],
-        "pluginId": "prometheus",
-        "refresh": "onDashboardLoad",
-        "regex": "RemoteWritePrometheus",
-        "skipUrlSync": false
-      }
-    },
-    {
-      "kind": "QueryVariable",
-      "spec": {
-        "allowCustomValue": true,
-        "current": {
-          "text": "AI4S",
-          "value": "AI4S"
-        },
-        "definition": "label_values(libvirt_domain_info_meta,instance_name)",
-        "description": "Name of your Virtual Machine instance as created on STFC Cloud OpenStack",
-        "hide": "dontHide",
-        "includeAll": false,
-        "label": "Virtual Machine Name",
-        "multi": false,
-        "name": "instance_name",
-        "options": [],
-        "query": {
-          "datasource": {
-            "name": "remote_write_prometheus"
-          },
-          "group": "prometheus",
-          "kind": "DataQuery",
-          "spec": {
-            "qryType": 1,
-            "query": "label_values(libvirt_domain_info_meta,instance_name)",
-            "refId": "PrometheusVariableQueryEditor-VariableQuery"
-          },
-          "version": "v0"
-        },
-        "refresh": "onDashboardLoad",
-        "regex": "",
-        "regexApplyTo": "value",
-        "skipUrlSync": false,
-        "sort": "disabled"
-      }
-    },
-    {
-      "kind": "QueryVariable",
-      "spec": {
-        "allowCustomValue": true,
-        "current": {
-          "text": "c3d23176-236b-4165-8aa4-33232ce21118",
-          "value": "c3d23176-236b-4165-8aa4-33232ce21118"
-        },
-        "definition": "label_values(libvirt_domain_info_meta{job=\"libvirt_exporter\", instance_name=~\"$instance_name\"},uuid)",
-        "description": "Virtual Machine UUID from STFC Cloud OpenStack",
-        "hide": "dontHide",
-        "includeAll": false,
-        "label": "VM uuid",
-        "multi": false,
-        "name": "uuid",
-        "options": [],
-        "query": {
-          "datasource": {
-            "name": "remote_write_prometheus"
-          },
-          "group": "prometheus",
-          "kind": "DataQuery",
-          "spec": {
-            "qryType": 1,
-            "query": "label_values(libvirt_domain_info_meta{job=\"libvirt_exporter\", instance_name=~\"$instance_name\"},uuid)",
-            "refId": "PrometheusVariableQueryEditor-VariableQuery"
-          },
-          "version": "v0"
-        },
-        "refresh": "onDashboardLoad",
-        "regex": "",
-        "regexApplyTo": "value",
-        "skipUrlSync": false,
-        "sort": "disabled"
-      }
-    },
-    {
-      "kind": "QueryVariable",
-      "spec": {
-        "allowCustomValue": true,
-        "current": {
-          "text": "hv-a100x8-6.nubes.rl.ac.uk",
-          "value": "hv-a100x8-6.nubes.rl.ac.uk"
-        },
-        "definition": "label_values(libvirt_domain_info_meta{job=\"libvirt_exporter\", uuid=~\"$uuid\"},instance)",
-        "hide": "dontHide",
-        "includeAll": false,
-        "label": "Hypervisor",
-        "multi": false,
-        "name": "Hypervisor",
-        "options": [],
-        "query": {
-          "datasource": {
-            "name": "remote_write_prometheus"
-          },
-          "group": "prometheus",
-          "kind": "DataQuery",
-          "spec": {
-            "qryType": 1,
-            "query": "label_values(libvirt_domain_info_meta{job=\"libvirt_exporter\", uuid=~\"$uuid\"},instance)",
-            "refId": "PrometheusVariableQueryEditor-VariableQuery"
-          },
-          "version": "v0"
-        },
-        "refresh": "onDashboardLoad",
-        "regex": "",
-        "regexApplyTo": "value",
-        "skipUrlSync": false,
-        "sort": "alphabeticalAsc"
-      }
-    },
-    {
-      "kind": "QueryVariable",
-      "spec": {
-        "allowCustomValue": false,
-        "current": {
-          "text": "All",
-          "value": "$__all"
-        },
-        "definition": "label_values(libvirt_domain_info_meta{job=\"libvirt_exporter\", instance_name=~\"$instance_name\"},domain)",
-        "hide": "dontHide",
-        "includeAll": true,
-        "label": "Domain",
-        "multi": false,
-        "name": "domain",
-        "options": [],
-        "query": {
-          "datasource": {
-            "name": "remote_write_prometheus"
-          },
-          "group": "prometheus",
-          "kind": "DataQuery",
-          "spec": {
-            "qryType": 1,
-            "query": "label_values(libvirt_domain_info_meta{job=\"libvirt_exporter\", instance_name=~\"$instance_name\"},domain)",
-            "refId": "PrometheusVariableQueryEditor-VariableQuery"
-          },
-          "version": "v0"
-        },
-        "refresh": "onDashboardLoad",
-        "regex": "",
-        "regexApplyTo": "value",
-        "skipUrlSync": false,
-        "sort": "disabled"
-      }
-    },
-    {
-      "kind": "ConstantVariable",
-      "spec": {
-        "current": {
-          "text": "126",
-          "value": "126"
-        },
-        "description": "",
-        "hide": "hideVariable",
-        "label": "",
-        "name": "carbon_intensity",
-        "query": "126",
-        "skipUrlSync": true
-      }
-    },
-    {
-      "kind": "ConstantVariable",
-      "spec": {
-        "current": {
-          "text": "1.3",
-          "value": "1.3"
-        },
-        "hide": "hideVariable",
-        "name": "pue",
-        "query": "1.3",
-        "skipUrlSync": true
-      }
-    }
-  ]
+  "version": 1,
+  "uid": "vm_power_and_carbon_method_1",
+  "id": 2323484798734336
 }

--- a/Virtual-Machines/vm_power_and_carbon_method_2.json
+++ b/Virtual-Machines/vm_power_and_carbon_method_2.json
@@ -1,4903 +1,3841 @@
 {
-  "annotations": [
-    {
-      "kind": "AnnotationQuery",
-      "spec": {
-        "builtIn": true,
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
         "name": "Annotations & Alerts",
-        "query": {
-          "datasource": {
-            "name": "-- Grafana --"
-          },
-          "group": "grafana",
-          "kind": "DataQuery",
-          "spec": {},
-          "version": "v0"
-        }
+        "type": "dashboard"
       }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 21,
+      "title": "Main",
+      "type": "row"
+    },
+    {
+      "gridPos": {
+        "h": 18,
+        "w": 18,
+        "x": 0,
+        "y": 1
+      },
+      "id": 8,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "# ⚡Virtual Machine Power & Carbon Emissions Dashboard Method 2\nThis dashboard estimates the **power consumption** and **carbon emissions** of an OpenStack Virtual Machine (VM) over a selected time period.<br>\nThe calculation is based on the VM’s allocated CPU cores and its utilisation relative to the host’s power profile.\n> ⚠️ The results represent an **approximation**, not an exact measurement of VM energy usage.<br>\n> ⚠️ This dashboard supports Compute (CPU) flavours only.<br>\n`GPU flavours are not supported and may produce incorrect estimates.`\n\n## 🧭 How to Use This Dashboard\n\n1. **Select your VM Instance Name:**<br>\nUse the Instance Name dropdown at the top of the dashboard to select your VM.<br>\n2. **Handle duplicate VM names (if applicable):**<br>\n-If multiple VMs share the same name:<br>\n-Go to: https://openstack.stfc.ac.uk<br>\n-Navigate to: Project → Instances<br>\n-Find the correct VM and copy its Instance ID (UUID)<br>\n-In Grafana, after selecting the instance name, choose the corresponding VM UUID from the UUID variable dropdown<br>\n5. **Select the time range:**<br>\nChoose the time period you want to analyse using the time picker.<br>\n6. **View the Results, the dashboard will display:**<br>\nEstimated VM power consumption<br>\nEstimated carbon emissions\n\n## 🧮 Calculation Method\nThe VM power consumption is estimated based on:<br>\n- How much of the host machine your VM is allocated (CPU cores)<br>\n- How actively your VM is using those CPU resources (utilisation)<br>\n- How the host server’s power changes between idle and full load<br>\n\n📐 Formula: `Average Watts = Min Watts + Avg vCPU Utilization * (Max Watts - Min Watts)`<br>\nSource: https://www.cloudcarbonfootprint.org/docs/methodology<br>\nImplemented equation: `VM Power ≈ (VM CPU Cores / Host CPU Cores) × [Host Min Power + VM Utilisation × (Host Max Power − Host Min Power)]`<br>\n\n\n## ⚠️ Important Limitations\nThe VM power attribution is calculated only from CPU resources and does not include:<br>\n- Memory (RAM) usage\n- Disk storage and I/O activity\n- Network traffic\n- GPU or accelerator usage<br>\n\nWorkloads that rely heavily on these resources may therefore have their actual energy usage under- or over-estimated.<br>\nTherefore, this dashboard currently supports only Compute (CPU) flavours.<br>\nGPU flavours are not supported and will not produce accurate power or carbon estimates.\n## 🌱 Purpose of This Dashboard:\nThis dashboard helps users:\n- Understand the energy footprint of their virtual machines.\n- Estimate carbon emissions of workloads\n- Support sustainability and energy awareness in using STFC Cloud",
+        "mode": "markdown"
+      },
+      "pluginVersion": "13.0.2",
+      "targets": [],
+      "title": "",
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "remote_write_prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "h"
+        }
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 6,
+        "x": 18,
+        "y": 1
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "13.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "code",
+          "expr": "$__range_s / 3600",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Duration",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "remote_write_prometheus"
+      },
+      "description": "UK average carbon intensity in 2025 is 126 gCO2/kWh. <br>\nSource: <br>\nhttps://www.carbonbrief.org/analysis-uk-renewables-enjoy-record-year-in-2025-but-gas-power-still-rises/ <br>\nhttps://www.energydashboard.co.uk/insights/2025-review",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "massg"
+        }
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 6,
+        "x": 18,
+        "y": 4
+      },
+      "id": 6,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "13.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "libvirt_domain_info_virtual_cpus{job=\"libvirt_exporter\", domain=~\"$domain\"}",
+          "instant": false,
+          "legendFormat": "VM_CPU_Core{{label_name}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "last_over_time(openstack_placement_resource_total{hostname=~\"$Hypervisor\", resourcetype=~\"PCPU|VCPU\"}[10m])",
+          "instant": false,
+          "legendFormat": "Host_CPU_Core{{label_name}}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "min(min_over_time(ipmi_dcmi_power_consumption_watts{instance=~\"$Hypervisor\"}[$__range]))",
+          "instant": false,
+          "legendFormat": "Host_Min_Watts{{label_name}}",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "max(max_over_time(ipmi_dcmi_power_consumption_watts{instance=~\"$Hypervisor\"}[$__range]))",
+          "instant": false,
+          "legendFormat": "Host_Max_Watts{{label_name}}",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "rate(libvirt_domain_info_cpu_time_seconds_total{job=\"libvirt_exporter\", domain=~\"$domain\"}[5m])\r\n/\r\non(domain)\r\ngroup_left()\r\nlibvirt_domain_info_virtual_cpus{job=\"libvirt_exporter\"}",
+          "instant": false,
+          "legendFormat": "VM_Utilisation{{label_name}}",
+          "range": true,
+          "refId": "E"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "code",
+          "expr": "$__range_s / 3600",
+          "instant": false,
+          "legendFormat": "Duration(hour){{label_name}}",
+          "range": true,
+          "refId": "F"
+        }
+      ],
+      "title": "🌍 Total Carbon Emission (gCO2)",
+      "transformations": [
+        {
+          "id": "calculateField",
+          "options": {
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "VM_CPU_Core"
+                }
+              },
+              "operator": "/",
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Host_CPU_Core"
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Host_Max_Watts"
+                }
+              },
+              "operator": "-",
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Host_Min_Watts"
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "VM_Utilisation"
+                }
+              },
+              "operator": "*",
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Host_Max_Watts - Host_Min_Watts"
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Host_Min_Watts"
+                }
+              },
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "VM_Utilisation * Host_Max_Watts - Host_Min_Watts"
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "VM Average Power (W)",
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "VM_CPU_Core / Host_CPU_Core"
+                }
+              },
+              "operator": "*",
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Host_Min_Watts + VM_Utilisation * Host_Max_Watts - Host_Min_Watts"
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": false
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Total VM Energy (Wh)",
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "VM Average Power (W)"
+                }
+              },
+              "operator": "*",
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Duration(hour)"
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "PUE",
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Total VM Energy (Wh)"
+                }
+              },
+              "operator": "*",
+              "right": {
+                "fixed": "1.3"
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": false
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Total VM Energy (Wh)",
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "PUE"
+                }
+              },
+              "operator": "*",
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Duration(hour)"
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Total VM Energy (kWh)",
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Total VM Energy (Wh)"
+                }
+              },
+              "operator": "/",
+              "right": {
+                "fixed": "1000"
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Total VM Energy (kWh)"
+                }
+              },
+              "operator": "*",
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "$carbon_intensity"
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": true
+          }
+        }
+      ],
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "remote_write_prometheus"
+      },
+      "description": "UK average carbon intensity in 2025 is 126 gCO2/kWh. <br>\nSource: <br>\nhttps://www.carbonbrief.org/analysis-uk-renewables-enjoy-record-year-in-2025-but-gas-power-still-rises/ <br>\nhttps://www.energydashboard.co.uk/insights/2025-review",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "massg"
+        }
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 6,
+        "x": 18,
+        "y": 7
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "13.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "libvirt_domain_info_virtual_cpus{job=\"libvirt_exporter\", domain=~\"$domain\"}",
+          "instant": false,
+          "legendFormat": "VM_CPU_Core{{label_name}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "last_over_time(openstack_placement_resource_total{hostname=~\"$Hypervisor\", resourcetype=~\"PCPU|VCPU\"}[10m])",
+          "instant": false,
+          "legendFormat": "Host_CPU_Core{{label_name}}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "min(min_over_time(ipmi_dcmi_power_consumption_watts{instance=~\"$Hypervisor\"}[$__range]))",
+          "instant": false,
+          "legendFormat": "Host_Min_Watts{{label_name}}",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "max(max_over_time(ipmi_dcmi_power_consumption_watts{instance=~\"$Hypervisor\"}[$__range]))",
+          "instant": false,
+          "legendFormat": "Host_Max_Watts{{label_name}}",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "rate(libvirt_domain_info_cpu_time_seconds_total{job=\"libvirt_exporter\", domain=~\"$domain\"}[5m])\r\n/\r\non(domain)\r\ngroup_left()\r\nlibvirt_domain_info_virtual_cpus{job=\"libvirt_exporter\"}",
+          "instant": false,
+          "legendFormat": "VM_Utilisation{{label_name}}",
+          "range": true,
+          "refId": "E"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "code",
+          "expr": "$__range_s / 3600",
+          "instant": false,
+          "legendFormat": "Duration(hour){{label_name}}",
+          "range": true,
+          "refId": "F"
+        }
+      ],
+      "title": "🌍 Carbon Emission of VM per Hour (gCO2)",
+      "transformations": [
+        {
+          "id": "calculateField",
+          "options": {
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "VM_CPU_Core"
+                }
+              },
+              "operator": "/",
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Host_CPU_Core"
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Host_Max_Watts"
+                }
+              },
+              "operator": "-",
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Host_Min_Watts"
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "VM_Utilisation"
+                }
+              },
+              "operator": "*",
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Host_Max_Watts - Host_Min_Watts"
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Host_Min_Watts"
+                }
+              },
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "VM_Utilisation * Host_Max_Watts - Host_Min_Watts"
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "VM Average Power (W)",
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "VM_CPU_Core / Host_CPU_Core"
+                }
+              },
+              "operator": "*",
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Host_Min_Watts + VM_Utilisation * Host_Max_Watts - Host_Min_Watts"
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": false
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "pue",
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "VM Average Power (W)"
+                }
+              },
+              "operator": "*",
+              "right": {
+                "fixed": "1.3"
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "VM Average Power (kW)",
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "pue"
+                }
+              },
+              "operator": "/",
+              "right": {
+                "fixed": "1000"
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "VM Average Power (kW)"
+                }
+              },
+              "operator": "*",
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "$carbon_intensity"
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": true
+          }
+        }
+      ],
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "remote_write_prometheus"
+      },
+      "description": "VM Power = (VM_CPU_core / Host_CPU_core) * [Host_Min_Watts + VM_Utilisation * (Host_Max_Watts - Host_Min_Watts)]",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "watt"
+        }
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 6,
+        "x": 18,
+        "y": 10
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "13.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "libvirt_domain_info_virtual_cpus{job=\"libvirt_exporter\", domain=~\"$domain\"}",
+          "instant": false,
+          "legendFormat": "VM_CPU_Core{{label_name}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "last_over_time(openstack_placement_resource_total{hostname=~\"$Hypervisor\", resourcetype=~\"PCPU|VCPU\"}[10m])",
+          "instant": false,
+          "legendFormat": "Host_CPU_Core{{label_name}}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "min(min_over_time(ipmi_dcmi_power_consumption_watts{instance=~\"$Hypervisor\"}[$__range]))",
+          "instant": false,
+          "legendFormat": "Host_Min_Watts{{label_name}}",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "max(max_over_time(ipmi_dcmi_power_consumption_watts{instance=~\"$Hypervisor\"}[$__range]))",
+          "instant": false,
+          "legendFormat": "Host_Max_Watts{{label_name}}",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "rate(libvirt_domain_info_cpu_time_seconds_total{job=\"libvirt_exporter\", domain=~\"$domain\"}[5m])\r\n/\r\non(domain)\r\ngroup_left()\r\nlibvirt_domain_info_virtual_cpus{job=\"libvirt_exporter\"}",
+          "instant": false,
+          "legendFormat": "VM_Utilisation{{label_name}}",
+          "range": true,
+          "refId": "E"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "code",
+          "expr": "$__range_s / 3600",
+          "instant": false,
+          "legendFormat": "Duration(hour){{label_name}}",
+          "range": true,
+          "refId": "F"
+        }
+      ],
+      "title": "⚡VM Average Power (W)",
+      "transformations": [
+        {
+          "id": "calculateField",
+          "options": {
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "VM_CPU_Core"
+                }
+              },
+              "operator": "/",
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Host_CPU_Core"
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Host_Max_Watts"
+                }
+              },
+              "operator": "-",
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Host_Min_Watts"
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "VM_Utilisation"
+                }
+              },
+              "operator": "*",
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Host_Max_Watts - Host_Min_Watts"
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Host_Min_Watts"
+                }
+              },
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "VM_Utilisation * Host_Max_Watts - Host_Min_Watts"
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "VM Average Power (W)",
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "VM_CPU_Core / Host_CPU_Core"
+                }
+              },
+              "operator": "*",
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Host_Min_Watts + VM_Utilisation * Host_Max_Watts - Host_Min_Watts"
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": true
+          }
+        }
+      ],
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "remote_write_prometheus"
+      },
+      "description": "VM Power = (VM_CPU_core / Host_CPU_core) * [Host_Min_Watts + VM_Utilisation * (Host_Max_Watts - Host_Min_Watts)]",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "watth"
+        }
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 6,
+        "x": 18,
+        "y": 13
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "13.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "libvirt_domain_info_virtual_cpus{job=\"libvirt_exporter\", domain=~\"$domain\"}",
+          "instant": false,
+          "legendFormat": "VM_CPU_Core{{label_name}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "last_over_time(openstack_placement_resource_total{hostname=~\"$Hypervisor\", resourcetype=~\"PCPU|VCPU\"}[10m])",
+          "instant": false,
+          "legendFormat": "Host_CPU_Core{{label_name}}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "min(min_over_time(ipmi_dcmi_power_consumption_watts{instance=~\"$Hypervisor\"}[$__range]))",
+          "instant": false,
+          "legendFormat": "Host_Min_Watts{{label_name}}",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "max(max_over_time(ipmi_dcmi_power_consumption_watts{instance=~\"$Hypervisor\"}[$__range]))",
+          "instant": false,
+          "legendFormat": "Host_Max_Watts{{label_name}}",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "rate(libvirt_domain_info_cpu_time_seconds_total{job=\"libvirt_exporter\", domain=~\"$domain\"}[5m])\r\n/\r\non(domain)\r\ngroup_left()\r\nlibvirt_domain_info_virtual_cpus{job=\"libvirt_exporter\"}",
+          "instant": false,
+          "legendFormat": "VM_Utilisation{{label_name}}",
+          "range": true,
+          "refId": "E"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "code",
+          "expr": "$__range_s / 3600",
+          "instant": false,
+          "legendFormat": "Duration(hour){{label_name}}",
+          "range": true,
+          "refId": "F"
+        }
+      ],
+      "title": "⚡VM Total Energy Used (Wh)",
+      "transformations": [
+        {
+          "id": "calculateField",
+          "options": {
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "VM_CPU_Core"
+                }
+              },
+              "operator": "/",
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Host_CPU_Core"
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Host_Max_Watts"
+                }
+              },
+              "operator": "-",
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Host_Min_Watts"
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "VM_Utilisation"
+                }
+              },
+              "operator": "*",
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Host_Max_Watts - Host_Min_Watts"
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Host_Min_Watts"
+                }
+              },
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "VM_Utilisation * Host_Max_Watts - Host_Min_Watts"
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "VM Average Power (W)",
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "VM_CPU_Core / Host_CPU_Core"
+                }
+              },
+              "operator": "*",
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Host_Min_Watts + VM_Utilisation * Host_Max_Watts - Host_Min_Watts"
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": false
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Total VM Energy (Wh)",
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "VM Average Power (W)"
+                }
+              },
+              "operator": "*",
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Duration(hour)"
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "PUE",
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Total VM Energy (Wh)"
+                }
+              },
+              "operator": "*",
+              "right": {
+                "fixed": "1.3"
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": true
+          }
+        }
+      ],
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "remote_write_prometheus"
+      },
+      "description": "As of 17th March 2026 <br>\nAverage electricity cost report by HPC Operation Costing Report is £0.21 per kWh. <br>\nElectricity Cost = Total Energy * 0.21 <br>\nSource: <br>\nhttp://cacti-master-virt.di.stfc.ac.uk/Information/CostingForm.php",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "currencyGBP"
+        }
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 6,
+        "x": 18,
+        "y": 16
+      },
+      "id": 7,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "13.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "libvirt_domain_info_virtual_cpus{job=\"libvirt_exporter\", domain=~\"$domain\"}",
+          "instant": false,
+          "legendFormat": "VM_CPU_Core{{label_name}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "last_over_time(openstack_placement_resource_total{hostname=~\"$Hypervisor\", resourcetype=~\"PCPU|VCPU\"}[10m])",
+          "instant": false,
+          "legendFormat": "Host_CPU_Core{{label_name}}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "min(min_over_time(ipmi_dcmi_power_consumption_watts{instance=~\"$Hypervisor\"}[$__range]))",
+          "instant": false,
+          "legendFormat": "Host_Min_Watts{{label_name}}",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "max(max_over_time(ipmi_dcmi_power_consumption_watts{instance=~\"$Hypervisor\"}[$__range]))",
+          "instant": false,
+          "legendFormat": "Host_Max_Watts{{label_name}}",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "rate(libvirt_domain_info_cpu_time_seconds_total{job=\"libvirt_exporter\", domain=~\"$domain\"}[5m])\r\n/\r\non(domain)\r\ngroup_left()\r\nlibvirt_domain_info_virtual_cpus{job=\"libvirt_exporter\"}",
+          "instant": false,
+          "legendFormat": "VM_Utilisation{{label_name}}",
+          "range": true,
+          "refId": "E"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "code",
+          "expr": "$__range_s / 3600",
+          "instant": false,
+          "legendFormat": "Duration(hour){{label_name}}",
+          "range": true,
+          "refId": "F"
+        }
+      ],
+      "title": "£ VM Energy Cost",
+      "transformations": [
+        {
+          "id": "calculateField",
+          "options": {
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "VM_CPU_Core"
+                }
+              },
+              "operator": "/",
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Host_CPU_Core"
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Host_Max_Watts"
+                }
+              },
+              "operator": "-",
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Host_Min_Watts"
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "VM_Utilisation"
+                }
+              },
+              "operator": "*",
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Host_Max_Watts - Host_Min_Watts"
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Host_Min_Watts"
+                }
+              },
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "VM_Utilisation * Host_Max_Watts - Host_Min_Watts"
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "VM Average Power (W)",
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "VM_CPU_Core / Host_CPU_Core"
+                }
+              },
+              "operator": "*",
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Host_Min_Watts + VM_Utilisation * Host_Max_Watts - Host_Min_Watts"
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": false
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Total VM Energy (Wh)",
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "VM Average Power (W)"
+                }
+              },
+              "operator": "*",
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Duration(hour)"
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Total VM Energy (kWh)",
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Total VM Energy (Wh)"
+                }
+              },
+              "operator": "/",
+              "right": {
+                "fixed": "1000"
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": false
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Total VM Energy (kWh) * PUE",
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Total VM Energy (kWh)"
+                }
+              },
+              "operator": "*",
+              "right": {
+                "fixed": "1.3"
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Price",
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Total VM Energy (kWh) * PUE"
+                }
+              },
+              "operator": "*",
+              "right": {
+                "fixed": "0.21"
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": true
+          }
+        }
+      ],
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "remote_write_prometheus"
+      },
+      "description": "Petrol cars had 143 gCO2/km\n=> 7150 gCO2 per hour driving (assuming 50km/h or 30mph)\nSource: 2022 UK GOV (https://www.gov.uk/government/statistics/vehicle-licensing-statistics-2022/vehicle-licensing-statistics-2022#carbon-co2-emissions-for-new-vehicle-registrations)",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "h"
+        }
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 19
+      },
+      "id": 9,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "13.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "libvirt_domain_info_virtual_cpus{job=\"libvirt_exporter\", domain=~\"$domain\"}",
+          "instant": false,
+          "legendFormat": "VM_CPU_Core{{label_name}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "last_over_time(openstack_placement_resource_total{hostname=~\"$Hypervisor\", resourcetype=~\"PCPU|VCPU\"}[10m])",
+          "instant": false,
+          "legendFormat": "Host_CPU_Core{{label_name}}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "min(min_over_time(ipmi_dcmi_power_consumption_watts{instance=~\"$Hypervisor\"}[$__range]))",
+          "instant": false,
+          "legendFormat": "Host_Min_Watts{{label_name}}",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "max(max_over_time(ipmi_dcmi_power_consumption_watts{instance=~\"$Hypervisor\"}[$__range]))",
+          "instant": false,
+          "legendFormat": "Host_Max_Watts{{label_name}}",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "rate(libvirt_domain_info_cpu_time_seconds_total{job=\"libvirt_exporter\", domain=~\"$domain\"}[5m])\r\n/\r\non(domain)\r\ngroup_left()\r\nlibvirt_domain_info_virtual_cpus{job=\"libvirt_exporter\"}",
+          "instant": false,
+          "legendFormat": "VM_Utilisation{{label_name}}",
+          "range": true,
+          "refId": "E"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "code",
+          "expr": "$__range_s / 3600",
+          "instant": false,
+          "legendFormat": "Duration(hour){{label_name}}",
+          "range": true,
+          "refId": "F"
+        }
+      ],
+      "title": "🚗 Driving a Petrol Car for",
+      "transformations": [
+        {
+          "id": "calculateField",
+          "options": {
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "VM_CPU_Core"
+                }
+              },
+              "operator": "/",
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Host_CPU_Core"
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Host_Max_Watts"
+                }
+              },
+              "operator": "-",
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Host_Min_Watts"
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "VM_Utilisation"
+                }
+              },
+              "operator": "*",
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Host_Max_Watts - Host_Min_Watts"
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Host_Min_Watts"
+                }
+              },
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "VM_Utilisation * Host_Max_Watts - Host_Min_Watts"
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "VM Average Power (W)",
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "VM_CPU_Core / Host_CPU_Core"
+                }
+              },
+              "operator": "*",
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Host_Min_Watts + VM_Utilisation * Host_Max_Watts - Host_Min_Watts"
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": false
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Total VM Energy (Wh)",
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "VM Average Power (W)"
+                }
+              },
+              "operator": "*",
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Duration(hour)"
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "PUE",
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Total VM Energy (Wh)"
+                }
+              },
+              "operator": "*",
+              "right": {
+                "fixed": "1.3"
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": false
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Total VM Energy (Wh)",
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "PUE"
+                }
+              },
+              "operator": "*",
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Duration(hour)"
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Total VM Energy (kWh)",
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Total VM Energy (Wh)"
+                }
+              },
+              "operator": "/",
+              "right": {
+                "fixed": "1000"
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "gCO2",
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Total VM Energy (kWh)"
+                }
+              },
+              "operator": "*",
+              "right": {
+                "fixed": "126"
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": false
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Car",
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "gCO2"
+                }
+              },
+              "operator": "/",
+              "right": {
+                "fixed": "7150"
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": true
+          }
+        }
+      ],
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "remote_write_prometheus"
+      },
+      "description": "A tree absorbs approximately 25kg of CO2 per year. <br>\nSource: <br>\nhttps://ecotree.green/en/how-much-co2-does-a-tree-absorb",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "Trees"
+        }
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 19
+      },
+      "id": 10,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "13.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "libvirt_domain_info_virtual_cpus{job=\"libvirt_exporter\", domain=~\"$domain\"}",
+          "instant": false,
+          "legendFormat": "VM_CPU_Core{{label_name}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "last_over_time(openstack_placement_resource_total{hostname=~\"$Hypervisor\", resourcetype=~\"PCPU|VCPU\"}[10m])",
+          "instant": false,
+          "legendFormat": "Host_CPU_Core{{label_name}}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "min(min_over_time(ipmi_dcmi_power_consumption_watts{instance=~\"$Hypervisor\"}[$__range]))",
+          "instant": false,
+          "legendFormat": "Host_Min_Watts{{label_name}}",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "max(max_over_time(ipmi_dcmi_power_consumption_watts{instance=~\"$Hypervisor\"}[$__range]))",
+          "instant": false,
+          "legendFormat": "Host_Max_Watts{{label_name}}",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "rate(libvirt_domain_info_cpu_time_seconds_total{job=\"libvirt_exporter\", domain=~\"$domain\"}[5m])\r\n/\r\non(domain)\r\ngroup_left()\r\nlibvirt_domain_info_virtual_cpus{job=\"libvirt_exporter\"}",
+          "instant": false,
+          "legendFormat": "VM_Utilisation{{label_name}}",
+          "range": true,
+          "refId": "E"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "code",
+          "expr": "$__range_s / 3600",
+          "instant": false,
+          "legendFormat": "Duration(hour){{label_name}}",
+          "range": true,
+          "refId": "F"
+        }
+      ],
+      "title": "🌳 Carbon absorbed in 1 year by",
+      "transformations": [
+        {
+          "id": "calculateField",
+          "options": {
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "VM_CPU_Core"
+                }
+              },
+              "operator": "/",
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Host_CPU_Core"
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Host_Max_Watts"
+                }
+              },
+              "operator": "-",
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Host_Min_Watts"
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "VM_Utilisation"
+                }
+              },
+              "operator": "*",
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Host_Max_Watts - Host_Min_Watts"
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Host_Min_Watts"
+                }
+              },
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "VM_Utilisation * Host_Max_Watts - Host_Min_Watts"
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "VM Average Power (W)",
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "VM_CPU_Core / Host_CPU_Core"
+                }
+              },
+              "operator": "*",
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Host_Min_Watts + VM_Utilisation * Host_Max_Watts - Host_Min_Watts"
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": false
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Total VM Energy (Wh)",
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "VM Average Power (W)"
+                }
+              },
+              "operator": "*",
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Duration(hour)"
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "PUE",
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Total VM Energy (Wh)"
+                }
+              },
+              "operator": "*",
+              "right": {
+                "fixed": "1.3"
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": false
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Total VM Energy (Wh)",
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "PUE"
+                }
+              },
+              "operator": "*",
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Duration(hour)"
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Total VM Energy (kWh)",
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Total VM Energy (Wh)"
+                }
+              },
+              "operator": "/",
+              "right": {
+                "fixed": "1000"
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "gCO2",
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Total VM Energy (kWh)"
+                }
+              },
+              "operator": "*",
+              "right": {
+                "fixed": "126"
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": false
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Tree",
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "gCO2"
+                }
+              },
+              "operator": "/",
+              "right": {
+                "fixed": "25000"
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": true
+          }
+        }
+      ],
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "remote_write_prometheus"
+      },
+      "description": "VM Power = (VM_CPU_core / Host_CPU_core) * [Host_Min_Watts + VM_Utilisation * (Host_Max_Watts - Host_Min_Watts)]",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": true,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "watt"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 23
+      },
+      "id": 1,
+      "options": {
+        "annotations": {
+          "clustering": -1,
+          "multiLane": false
+        },
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "mean",
+            "diffperc"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "13.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "libvirt_domain_info_virtual_cpus{job=\"libvirt_exporter\", domain=~\"$domain\"}",
+          "instant": false,
+          "legendFormat": "VM_CPU_Core{{label_name}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "code",
+          "expr": "last_over_time(openstack_placement_resource_total{hostname=~\"$Hypervisor\", resourcetype=~\"PCPU|VCPU\"}[10m])",
+          "instant": false,
+          "legendFormat": "Host_CPU_Core{{label_name}}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "min(min_over_time(ipmi_dcmi_power_consumption_watts{instance=~\"$Hypervisor\"}[$__range]))",
+          "instant": false,
+          "legendFormat": "Host_Min_Watts{{label_name}}",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "max(max_over_time(ipmi_dcmi_power_consumption_watts{instance=~\"$Hypervisor\"}[$__range]))",
+          "instant": false,
+          "legendFormat": "Host_Max_Watts{{label_name}}",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "code",
+          "expr": "rate(libvirt_domain_info_cpu_time_seconds_total{job=\"libvirt_exporter\", domain=~\"$domain\"}[5m])\r\n/\r\non(domain)\r\ngroup_left()\r\nlibvirt_domain_info_virtual_cpus{job=\"libvirt_exporter\"}",
+          "instant": false,
+          "legendFormat": "VM_Utilisation{{label_name}}",
+          "range": true,
+          "refId": "E"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "code",
+          "expr": "$__range_s / 3600",
+          "instant": false,
+          "legendFormat": "Duration(hour){{label_name}}",
+          "range": true,
+          "refId": "F"
+        }
+      ],
+      "title": "VM Power Timeline",
+      "transformations": [
+        {
+          "id": "calculateField",
+          "options": {
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "VM_CPU_Core"
+                }
+              },
+              "operator": "/",
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Host_CPU_Core"
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Host_Max_Watts"
+                }
+              },
+              "operator": "-",
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Host_Min_Watts"
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "VM_Utilisation"
+                }
+              },
+              "operator": "*",
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Host_Max_Watts - Host_Min_Watts"
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Host_Min_Watts"
+                }
+              },
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "VM_Utilisation * Host_Max_Watts - Host_Min_Watts"
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "VM Average Power (W)",
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "VM_CPU_Core / Host_CPU_Core"
+                }
+              },
+              "operator": "*",
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Host_Min_Watts + VM_Utilisation * Host_Max_Watts - Host_Min_Watts"
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": true
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 31
+      },
+      "id": 22,
+      "title": "Host & VM Metrics",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "remote_write_prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        }
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 6,
+        "x": 0,
+        "y": 32
+      },
+      "id": 11,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "text": {
+          "valueSize": 25
+        },
+        "textMode": "name",
+        "wideLayout": true
+      },
+      "pluginVersion": "13.0.1+security-01",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "exemplar": false,
+          "expr": "max by (hostname, aggregates) (\r\n  (\r\n    libvirt_domain_info_meta{job=\"libvirt_exporter\", uuid=~\"$uuid\"}\r\n  )\r\n  * on(instance)\r\n  group_left(hostname, aggregates)\r\n  label_replace(\r\n    openstack_nova_current_workload,\r\n    \"instance\", \"$1\", \"hostname\", \"(.*)\"\r\n  )\r\n)",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "Host: {{hostname}} Model: {{aggregates}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "VM Location",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "remote_write_prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        }
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 6,
+        "y": 32
+      },
+      "id": 12,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "text": {
+          "valueSize": 25
+        },
+        "textMode": "name",
+        "wideLayout": true
+      },
+      "pluginVersion": "13.0.1+security-01",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "libvirt_domain_info_meta{job=\"libvirt_exporter\", uuid=~\"$uuid\"}",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "{{flavor}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "VM Flavour",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "remote_write_prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        }
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 6,
+        "x": 10,
+        "y": 32
+      },
+      "id": 14,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "text": {
+          "valueSize": 25
+        },
+        "textMode": "name",
+        "wideLayout": true
+      },
+      "pluginVersion": "13.0.1+security-01",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "libvirt_domain_info_meta{job=\"libvirt_exporter\", uuid=~\"$uuid\"}",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "{{project_name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "VM - Project Name",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "remote_write_prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        }
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 6,
+        "x": 16,
+        "y": 32
+      },
+      "id": 13,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "text": {
+          "valueSize": 25
+        },
+        "textMode": "name",
+        "wideLayout": true
+      },
+      "pluginVersion": "13.0.1+security-01",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "exemplar": false,
+          "expr": "count by(instance) (libvirt_domain_info_meta{job=\"libvirt_exporter\", instance=~\"$Hypervisor\"})",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Number of instances(VM) on Host",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "remote_write_prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        }
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 3,
+        "x": 0,
+        "y": 35
+      },
+      "id": 15,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "text": {
+          "valueSize": 25
+        },
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "13.0.1+security-01",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "last_over_time(openstack_placement_resource_total{hostname=~\"$Hypervisor\", resourcetype=~\"PCPU|VCU\"}[10m])",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Host CPU Core",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "remote_write_prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        }
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 3,
+        "x": 3,
+        "y": 35
+      },
+      "id": 16,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "text": {
+          "valueSize": 25
+        },
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "13.0.1+security-01",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "exemplar": false,
+          "expr": "libvirt_domain_info_virtual_cpus{job=\"libvirt_exporter\", domain=~\"$domain\"} * on(instance) libvirt_domain_info_meta{job=\"libvirt_exporter\", uuid=~\"$uuid\"}",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "VM CPU Core",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "remote_write_prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        }
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 3,
+        "x": 6,
+        "y": 35
+      },
+      "id": 17,
+      "options": {
+        "annotations": {
+          "clustering": -1,
+          "multiLane": false
+        },
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "13.0.1+security-01",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "exemplar": false,
+          "expr": "max(max_over_time(ipmi_dcmi_power_consumption_watts{instance=~\"$Hypervisor\"}[$__range]))",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Host Max Watts",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "remote_write_prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        }
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 3,
+        "x": 9,
+        "y": 35
+      },
+      "id": 18,
+      "options": {
+        "annotations": {
+          "clustering": -1,
+          "multiLane": false
+        },
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "13.0.1+security-01",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "exemplar": false,
+          "expr": "min(min_over_time(ipmi_dcmi_power_consumption_watts{instance=~\"$Hypervisor\"}[$__range]))",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Host Min Watts",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "remote_write_prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        }
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 3,
+        "x": 12,
+        "y": 35
+      },
+      "id": 19,
+      "options": {
+        "annotations": {
+          "clustering": -1,
+          "multiLane": false
+        },
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "13.0.1+security-01",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "rate(libvirt_domain_info_cpu_time_seconds_total{job=\"libvirt_exporter\", domain=~\"$domain\"}[5m])\r\n/\r\non(domain)\r\ngroup_left()\r\nlibvirt_domain_info_virtual_cpus{job=\"libvirt_exporter\"}",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "VM CPU Utilisation (by VCPU Count)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "remote_write_prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        }
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 3,
+        "x": 15,
+        "y": 35
+      },
+      "id": 20,
+      "options": {
+        "annotations": {
+          "clustering": -1,
+          "multiLane": false
+        },
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "13.0.1+security-01",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "remote_write_prometheus"
+          },
+          "editorMode": "builder",
+          "exemplar": false,
+          "expr": "sum by(instance) (irate(libvirt_domain_info_cpu_time_seconds_total{job=\"libvirt_exporter\", domain=~\"$domain\"}[2m])) * on(instance) libvirt_domain_info_meta{job=\"libvirt_exporter\", uuid=~\"$uuid\"}",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Host CPU Utilisation",
+      "type": "timeseries"
     }
   ],
-  "cursorSync": "Off",
-  "editable": true,
-  "elements": {
-    "panel-1": {
-      "kind": "Panel",
-      "spec": {
-        "data": {
-          "kind": "QueryGroup",
-          "spec": {
-            "queries": [
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "expr": "libvirt_domain_info_virtual_cpus{job=\"libvirt_exporter\", domain=~\"$domain\"}",
-                      "instant": false,
-                      "legendFormat": "VM_CPU_Core{{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "A"
-                }
-              },
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "code",
-                      "expr": "last_over_time(openstack_placement_resource_total{hostname=~\"$Hypervisor\", resourcetype=~\"PCPU|VCPU\"}[10m])",
-                      "instant": false,
-                      "legendFormat": "Host_CPU_Core{{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "B"
-                }
-              },
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "expr": "min(min_over_time(ipmi_dcmi_power_consumption_watts{instance=~\"$Hypervisor\"}[$__range]))",
-                      "instant": false,
-                      "legendFormat": "Host_Min_Watts{{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "C"
-                }
-              },
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "expr": "max(max_over_time(ipmi_dcmi_power_consumption_watts{instance=~\"$Hypervisor\"}[$__range]))",
-                      "instant": false,
-                      "legendFormat": "Host_Max_Watts{{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "D"
-                }
-              },
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "code",
-                      "expr": "rate(libvirt_domain_info_cpu_time_seconds_total{job=\"libvirt_exporter\", domain=~\"$domain\"}[5m])\r\n/\r\non(domain)\r\ngroup_left()\r\nlibvirt_domain_info_virtual_cpus{job=\"libvirt_exporter\"}",
-                      "instant": false,
-                      "legendFormat": "VM_Utilisation{{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "E"
-                }
-              },
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "code",
-                      "expr": "$__range_s / 3600",
-                      "instant": false,
-                      "legendFormat": "Duration(hour){{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "F"
-                }
-              }
-            ],
-            "queryOptions": {},
-            "transformations": [
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "VM_CPU_Core"
-                        }
-                      },
-                      "operator": "/",
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Host_CPU_Core"
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    }
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Host_Max_Watts"
-                        }
-                      },
-                      "operator": "-",
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Host_Min_Watts"
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    }
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "VM_Utilisation"
-                        }
-                      },
-                      "operator": "*",
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Host_Max_Watts - Host_Min_Watts"
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    }
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Host_Min_Watts"
-                        }
-                      },
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "VM_Utilisation * Host_Max_Watts - Host_Min_Watts"
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    }
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "alias": "VM Average Power (W)",
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "VM_CPU_Core / Host_CPU_Core"
-                        }
-                      },
-                      "operator": "*",
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Host_Min_Watts + VM_Utilisation * Host_Max_Watts - Host_Min_Watts"
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    },
-                    "replaceFields": true
-                  }
-                }
-              }
-            ]
-          }
-        },
-        "description": "VM Power = (VM_CPU_core / Host_CPU_core) * [Host_Min_Watts + VM_Utilisation * (Host_Max_Watts - Host_Min_Watts)]",
-        "id": 1,
-        "links": [],
-        "title": "VM Power Timeline",
-        "vizConfig": {
-          "group": "timeseries",
-          "kind": "VizConfig",
-          "spec": {
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "palette-classic"
-                },
-                "custom": {
-                  "axisBorderShow": true,
-                  "axisCenteredZero": false,
-                  "axisColorMode": "text",
-                  "axisLabel": "",
-                  "axisPlacement": "auto",
-                  "barAlignment": 0,
-                  "barWidthFactor": 0.6,
-                  "drawStyle": "line",
-                  "fillOpacity": 0,
-                  "gradientMode": "none",
-                  "hideFrom": {
-                    "legend": false,
-                    "tooltip": false,
-                    "viz": false
-                  },
-                  "insertNulls": false,
-                  "lineInterpolation": "linear",
-                  "lineStyle": {
-                    "fill": "solid"
-                  },
-                  "lineWidth": 1,
-                  "pointSize": 5,
-                  "scaleDistribution": {
-                    "type": "linear"
-                  },
-                  "showPoints": "auto",
-                  "showValues": false,
-                  "spanNulls": false,
-                  "stacking": {
-                    "group": "A",
-                    "mode": "none"
-                  },
-                  "thresholdsStyle": {
-                    "mode": "off"
-                  }
-                },
-                "fieldMinMax": false,
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "watt"
-              },
-              "overrides": []
-            },
-            "options": {
-              "annotations": {
-                "clustering": -1,
-                "multiLane": false
-              },
-              "legend": {
-                "calcs": [
-                  "lastNotNull",
-                  "mean",
-                  "diffperc"
-                ],
-                "displayMode": "list",
-                "placement": "bottom",
-                "showLegend": true
-              },
-              "tooltip": {
-                "hideZeros": false,
-                "mode": "single",
-                "sort": "none"
-              }
-            }
-          },
-          "version": "13.0.2"
-        }
-      }
-    },
-    "panel-10": {
-      "kind": "Panel",
-      "spec": {
-        "data": {
-          "kind": "QueryGroup",
-          "spec": {
-            "queries": [
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "expr": "libvirt_domain_info_virtual_cpus{job=\"libvirt_exporter\", domain=~\"$domain\"}",
-                      "instant": false,
-                      "legendFormat": "VM_CPU_Core{{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "A"
-                }
-              },
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "expr": "last_over_time(openstack_placement_resource_total{hostname=~\"$Hypervisor\", resourcetype=~\"PCPU|VCPU\"}[10m])",
-                      "instant": false,
-                      "legendFormat": "Host_CPU_Core{{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "B"
-                }
-              },
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "expr": "min(min_over_time(ipmi_dcmi_power_consumption_watts{instance=~\"$Hypervisor\"}[$__range]))",
-                      "instant": false,
-                      "legendFormat": "Host_Min_Watts{{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "C"
-                }
-              },
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "expr": "max(max_over_time(ipmi_dcmi_power_consumption_watts{instance=~\"$Hypervisor\"}[$__range]))",
-                      "instant": false,
-                      "legendFormat": "Host_Max_Watts{{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "D"
-                }
-              },
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "expr": "rate(libvirt_domain_info_cpu_time_seconds_total{job=\"libvirt_exporter\", domain=~\"$domain\"}[5m])\r\n/\r\non(domain)\r\ngroup_left()\r\nlibvirt_domain_info_virtual_cpus{job=\"libvirt_exporter\"}",
-                      "instant": false,
-                      "legendFormat": "VM_Utilisation{{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "E"
-                }
-              },
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "code",
-                      "expr": "$__range_s / 3600",
-                      "instant": false,
-                      "legendFormat": "Duration(hour){{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "F"
-                }
-              }
-            ],
-            "queryOptions": {},
-            "transformations": [
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "VM_CPU_Core"
-                        }
-                      },
-                      "operator": "/",
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Host_CPU_Core"
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    }
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Host_Max_Watts"
-                        }
-                      },
-                      "operator": "-",
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Host_Min_Watts"
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    }
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "VM_Utilisation"
-                        }
-                      },
-                      "operator": "*",
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Host_Max_Watts - Host_Min_Watts"
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    }
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Host_Min_Watts"
-                        }
-                      },
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "VM_Utilisation * Host_Max_Watts - Host_Min_Watts"
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    }
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "alias": "VM Average Power (W)",
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "VM_CPU_Core / Host_CPU_Core"
-                        }
-                      },
-                      "operator": "*",
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Host_Min_Watts + VM_Utilisation * Host_Max_Watts - Host_Min_Watts"
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    },
-                    "replaceFields": false
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "alias": "Total VM Energy (Wh)",
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "VM Average Power (W)"
-                        }
-                      },
-                      "operator": "*",
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Duration(hour)"
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    }
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "alias": "PUE",
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Total VM Energy (Wh)"
-                        }
-                      },
-                      "operator": "*",
-                      "right": {
-                        "fixed": "1.3"
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    },
-                    "replaceFields": false
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "alias": "Total VM Energy (Wh)",
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "PUE"
-                        }
-                      },
-                      "operator": "*",
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Duration(hour)"
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    }
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "alias": "Total VM Energy (kWh)",
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Total VM Energy (Wh)"
-                        }
-                      },
-                      "operator": "/",
-                      "right": {
-                        "fixed": "1000"
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    }
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "alias": "gCO2",
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Total VM Energy (kWh)"
-                        }
-                      },
-                      "operator": "*",
-                      "right": {
-                        "fixed": "126"
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    },
-                    "replaceFields": false
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "alias": "Tree",
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "gCO2"
-                        }
-                      },
-                      "operator": "/",
-                      "right": {
-                        "fixed": "25000"
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    },
-                    "replaceFields": true
-                  }
-                }
-              }
-            ]
-          }
-        },
-        "description": "A tree absorbs approximately 25kg of CO2 per year. <br>\nSource: <br>\nhttps://ecotree.green/en/how-much-co2-does-a-tree-absorb",
-        "id": 10,
-        "links": [],
-        "title": "🌳 Carbon absorbed in 1 year by",
-        "vizConfig": {
-          "group": "stat",
-          "kind": "VizConfig",
-          "spec": {
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "thresholds"
-                },
-                "decimals": 2,
-                "fieldMinMax": false,
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "Trees"
-              },
-              "overrides": []
-            },
-            "options": {
-              "colorMode": "none",
-              "graphMode": "none",
-              "justifyMode": "auto",
-              "orientation": "auto",
-              "percentChangeColorMode": "standard",
-              "reduceOptions": {
-                "calcs": [
-                  "lastNotNull"
-                ],
-                "fields": "",
-                "values": false
-              },
-              "showPercentChange": false,
-              "textMode": "auto",
-              "wideLayout": true
-            }
-          },
-          "version": "13.0.2"
-        }
-      }
-    },
-    "panel-11": {
-      "kind": "Panel",
-      "spec": {
-        "data": {
-          "kind": "QueryGroup",
-          "spec": {
-            "queries": [
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "exemplar": false,
-                      "expr": "max by (hostname, aggregates) (\r\n  (\r\n    libvirt_domain_info_meta{job=\"libvirt_exporter\", uuid=~\"$uuid\"}\r\n  )\r\n  * on(instance)\r\n  group_left(hostname, aggregates)\r\n  label_replace(\r\n    openstack_nova_current_workload,\r\n    \"instance\", \"$1\", \"hostname\", \"(.*)\"\r\n  )\r\n)",
-                      "format": "time_series",
-                      "instant": false,
-                      "interval": "",
-                      "legendFormat": "Host: {{hostname}} Model: {{aggregates}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "A"
-                }
-              }
-            ],
-            "queryOptions": {},
-            "transformations": []
-          }
-        },
-        "description": "",
-        "id": 11,
-        "links": [],
-        "title": "VM Location",
-        "vizConfig": {
-          "group": "stat",
-          "kind": "VizConfig",
-          "spec": {
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "thresholds"
-                },
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                }
-              },
-              "overrides": []
-            },
-            "options": {
-              "colorMode": "none",
-              "graphMode": "none",
-              "justifyMode": "auto",
-              "orientation": "auto",
-              "percentChangeColorMode": "standard",
-              "reduceOptions": {
-                "calcs": [
-                  "lastNotNull"
-                ],
-                "fields": "",
-                "values": false
-              },
-              "showPercentChange": false,
-              "text": {
-                "valueSize": 25
-              },
-              "textMode": "name",
-              "wideLayout": true
-            }
-          },
-          "version": "13.0.1+security-01"
-        }
-      }
-    },
-    "panel-12": {
-      "kind": "Panel",
-      "spec": {
-        "data": {
-          "kind": "QueryGroup",
-          "spec": {
-            "queries": [
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "code",
-                      "exemplar": false,
-                      "expr": "libvirt_domain_info_meta{job=\"libvirt_exporter\", uuid=~\"$uuid\"}",
-                      "format": "time_series",
-                      "instant": false,
-                      "interval": "",
-                      "legendFormat": "{{flavor}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "A"
-                }
-              }
-            ],
-            "queryOptions": {},
-            "transformations": []
-          }
-        },
-        "description": "",
-        "id": 12,
-        "links": [],
-        "title": "VM Flavour",
-        "vizConfig": {
-          "group": "stat",
-          "kind": "VizConfig",
-          "spec": {
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "thresholds"
-                },
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                }
-              },
-              "overrides": []
-            },
-            "options": {
-              "colorMode": "none",
-              "graphMode": "none",
-              "justifyMode": "auto",
-              "orientation": "auto",
-              "percentChangeColorMode": "standard",
-              "reduceOptions": {
-                "calcs": [
-                  "lastNotNull"
-                ],
-                "fields": "",
-                "values": false
-              },
-              "showPercentChange": false,
-              "text": {
-                "valueSize": 25
-              },
-              "textMode": "name",
-              "wideLayout": true
-            }
-          },
-          "version": "13.0.1+security-01"
-        }
-      }
-    },
-    "panel-13": {
-      "kind": "Panel",
-      "spec": {
-        "data": {
-          "kind": "QueryGroup",
-          "spec": {
-            "queries": [
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "exemplar": false,
-                      "expr": "count by(instance) (libvirt_domain_info_meta{job=\"libvirt_exporter\", instance=~\"$Hypervisor\"})",
-                      "format": "time_series",
-                      "instant": false,
-                      "interval": "",
-                      "legendFormat": "__auto",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "A"
-                }
-              }
-            ],
-            "queryOptions": {},
-            "transformations": []
-          }
-        },
-        "description": "",
-        "id": 13,
-        "links": [],
-        "title": "Number of instances(VM) on Host",
-        "vizConfig": {
-          "group": "stat",
-          "kind": "VizConfig",
-          "spec": {
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "thresholds"
-                },
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                }
-              },
-              "overrides": []
-            },
-            "options": {
-              "colorMode": "none",
-              "graphMode": "none",
-              "justifyMode": "auto",
-              "orientation": "auto",
-              "percentChangeColorMode": "standard",
-              "reduceOptions": {
-                "calcs": [
-                  "lastNotNull"
-                ],
-                "fields": "",
-                "values": false
-              },
-              "showPercentChange": false,
-              "text": {
-                "valueSize": 25
-              },
-              "textMode": "name",
-              "wideLayout": true
-            }
-          },
-          "version": "13.0.1+security-01"
-        }
-      }
-    },
-    "panel-14": {
-      "kind": "Panel",
-      "spec": {
-        "data": {
-          "kind": "QueryGroup",
-          "spec": {
-            "queries": [
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "code",
-                      "exemplar": false,
-                      "expr": "libvirt_domain_info_meta{job=\"libvirt_exporter\", uuid=~\"$uuid\"}",
-                      "format": "time_series",
-                      "instant": false,
-                      "interval": "",
-                      "legendFormat": "{{project_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "A"
-                }
-              }
-            ],
-            "queryOptions": {},
-            "transformations": []
-          }
-        },
-        "description": "",
-        "id": 14,
-        "links": [],
-        "title": "VM - Project Name",
-        "vizConfig": {
-          "group": "stat",
-          "kind": "VizConfig",
-          "spec": {
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "thresholds"
-                },
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                }
-              },
-              "overrides": []
-            },
-            "options": {
-              "colorMode": "none",
-              "graphMode": "none",
-              "justifyMode": "auto",
-              "orientation": "auto",
-              "percentChangeColorMode": "standard",
-              "reduceOptions": {
-                "calcs": [
-                  "lastNotNull"
-                ],
-                "fields": "",
-                "values": false
-              },
-              "showPercentChange": false,
-              "text": {
-                "valueSize": 25
-              },
-              "textMode": "name",
-              "wideLayout": true
-            }
-          },
-          "version": "13.0.1+security-01"
-        }
-      }
-    },
-    "panel-15": {
-      "kind": "Panel",
-      "spec": {
-        "data": {
-          "kind": "QueryGroup",
-          "spec": {
-            "queries": [
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "code",
-                      "exemplar": false,
-                      "expr": "last_over_time(openstack_placement_resource_total{hostname=~\"$Hypervisor\", resourcetype=~\"PCPU|VCU\"}[10m])",
-                      "format": "time_series",
-                      "instant": false,
-                      "interval": "",
-                      "legendFormat": "__auto",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "A"
-                }
-              }
-            ],
-            "queryOptions": {},
-            "transformations": []
-          }
-        },
-        "description": "",
-        "id": 15,
-        "links": [],
-        "title": "Host CPU Core",
-        "vizConfig": {
-          "group": "stat",
-          "kind": "VizConfig",
-          "spec": {
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "thresholds"
-                },
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                }
-              },
-              "overrides": []
-            },
-            "options": {
-              "colorMode": "none",
-              "graphMode": "none",
-              "justifyMode": "auto",
-              "orientation": "auto",
-              "percentChangeColorMode": "standard",
-              "reduceOptions": {
-                "calcs": [
-                  "lastNotNull"
-                ],
-                "fields": "",
-                "values": false
-              },
-              "showPercentChange": false,
-              "text": {
-                "valueSize": 25
-              },
-              "textMode": "value",
-              "wideLayout": true
-            }
-          },
-          "version": "13.0.1+security-01"
-        }
-      }
-    },
-    "panel-16": {
-      "kind": "Panel",
-      "spec": {
-        "data": {
-          "kind": "QueryGroup",
-          "spec": {
-            "queries": [
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "exemplar": false,
-                      "expr": "libvirt_domain_info_virtual_cpus{job=\"libvirt_exporter\", domain=~\"$domain\"} * on(instance) libvirt_domain_info_meta{job=\"libvirt_exporter\", uuid=~\"$uuid\"}",
-                      "format": "time_series",
-                      "instant": false,
-                      "interval": "",
-                      "legendFormat": "__auto",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "A"
-                }
-              }
-            ],
-            "queryOptions": {},
-            "transformations": []
-          }
-        },
-        "description": "",
-        "id": 16,
-        "links": [],
-        "title": "VM CPU Core",
-        "vizConfig": {
-          "group": "stat",
-          "kind": "VizConfig",
-          "spec": {
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "thresholds"
-                },
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                }
-              },
-              "overrides": []
-            },
-            "options": {
-              "colorMode": "none",
-              "graphMode": "none",
-              "justifyMode": "auto",
-              "orientation": "auto",
-              "percentChangeColorMode": "standard",
-              "reduceOptions": {
-                "calcs": [
-                  "lastNotNull"
-                ],
-                "fields": "",
-                "values": false
-              },
-              "showPercentChange": false,
-              "text": {
-                "valueSize": 25
-              },
-              "textMode": "value",
-              "wideLayout": true
-            }
-          },
-          "version": "13.0.1+security-01"
-        }
-      }
-    },
-    "panel-17": {
-      "kind": "Panel",
-      "spec": {
-        "data": {
-          "kind": "QueryGroup",
-          "spec": {
-            "queries": [
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "exemplar": false,
-                      "expr": "max(max_over_time(ipmi_dcmi_power_consumption_watts{instance=~\"$Hypervisor\"}[$__range]))",
-                      "format": "time_series",
-                      "instant": false,
-                      "interval": "",
-                      "legendFormat": "__auto",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "A"
-                }
-              }
-            ],
-            "queryOptions": {},
-            "transformations": []
-          }
-        },
-        "description": "",
-        "id": 17,
-        "links": [],
-        "title": "Host Max Watts",
-        "vizConfig": {
-          "group": "timeseries",
-          "kind": "VizConfig",
-          "spec": {
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "palette-classic"
-                },
-                "custom": {
-                  "axisBorderShow": false,
-                  "axisCenteredZero": false,
-                  "axisColorMode": "text",
-                  "axisLabel": "",
-                  "axisPlacement": "auto",
-                  "barAlignment": 0,
-                  "barWidthFactor": 0.6,
-                  "drawStyle": "line",
-                  "fillOpacity": 0,
-                  "gradientMode": "none",
-                  "hideFrom": {
-                    "legend": false,
-                    "tooltip": false,
-                    "viz": false
-                  },
-                  "insertNulls": false,
-                  "lineInterpolation": "linear",
-                  "lineWidth": 1,
-                  "pointSize": 5,
-                  "scaleDistribution": {
-                    "type": "linear"
-                  },
-                  "showPoints": "auto",
-                  "showValues": false,
-                  "spanNulls": false,
-                  "stacking": {
-                    "group": "A",
-                    "mode": "none"
-                  },
-                  "thresholdsStyle": {
-                    "mode": "off"
-                  }
-                },
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                }
-              },
-              "overrides": []
-            },
-            "options": {
-              "annotations": {
-                "clustering": -1,
-                "multiLane": false
-              },
-              "legend": {
-                "calcs": [],
-                "displayMode": "list",
-                "placement": "bottom",
-                "showLegend": true
-              },
-              "tooltip": {
-                "hideZeros": false,
-                "mode": "single",
-                "sort": "none"
-              }
-            }
-          },
-          "version": "13.0.1+security-01"
-        }
-      }
-    },
-    "panel-18": {
-      "kind": "Panel",
-      "spec": {
-        "data": {
-          "kind": "QueryGroup",
-          "spec": {
-            "queries": [
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "exemplar": false,
-                      "expr": "min(min_over_time(ipmi_dcmi_power_consumption_watts{instance=~\"$Hypervisor\"}[$__range]))",
-                      "format": "time_series",
-                      "instant": false,
-                      "interval": "",
-                      "legendFormat": "__auto",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "A"
-                }
-              }
-            ],
-            "queryOptions": {},
-            "transformations": []
-          }
-        },
-        "description": "",
-        "id": 18,
-        "links": [],
-        "title": "Host Min Watts",
-        "vizConfig": {
-          "group": "timeseries",
-          "kind": "VizConfig",
-          "spec": {
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "palette-classic"
-                },
-                "custom": {
-                  "axisBorderShow": false,
-                  "axisCenteredZero": false,
-                  "axisColorMode": "text",
-                  "axisLabel": "",
-                  "axisPlacement": "auto",
-                  "barAlignment": 0,
-                  "barWidthFactor": 0.6,
-                  "drawStyle": "line",
-                  "fillOpacity": 0,
-                  "gradientMode": "none",
-                  "hideFrom": {
-                    "legend": false,
-                    "tooltip": false,
-                    "viz": false
-                  },
-                  "insertNulls": false,
-                  "lineInterpolation": "linear",
-                  "lineWidth": 1,
-                  "pointSize": 5,
-                  "scaleDistribution": {
-                    "type": "linear"
-                  },
-                  "showPoints": "auto",
-                  "showValues": false,
-                  "spanNulls": false,
-                  "stacking": {
-                    "group": "A",
-                    "mode": "none"
-                  },
-                  "thresholdsStyle": {
-                    "mode": "off"
-                  }
-                },
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                }
-              },
-              "overrides": []
-            },
-            "options": {
-              "annotations": {
-                "clustering": -1,
-                "multiLane": false
-              },
-              "legend": {
-                "calcs": [],
-                "displayMode": "list",
-                "placement": "bottom",
-                "showLegend": true
-              },
-              "tooltip": {
-                "hideZeros": false,
-                "mode": "single",
-                "sort": "none"
-              }
-            }
-          },
-          "version": "13.0.1+security-01"
-        }
-      }
-    },
-    "panel-19": {
-      "kind": "Panel",
-      "spec": {
-        "data": {
-          "kind": "QueryGroup",
-          "spec": {
-            "queries": [
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "code",
-                      "exemplar": false,
-                      "expr": "rate(libvirt_domain_info_cpu_time_seconds_total{job=\"libvirt_exporter\", domain=~\"$domain\"}[5m])\r\n/\r\non(domain)\r\ngroup_left()\r\nlibvirt_domain_info_virtual_cpus{job=\"libvirt_exporter\"}",
-                      "format": "time_series",
-                      "instant": false,
-                      "interval": "",
-                      "legendFormat": "__auto",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "A"
-                }
-              }
-            ],
-            "queryOptions": {},
-            "transformations": []
-          }
-        },
-        "description": "",
-        "id": 19,
-        "links": [],
-        "title": "VM CPU Utilisation (by VCPU Count)",
-        "vizConfig": {
-          "group": "timeseries",
-          "kind": "VizConfig",
-          "spec": {
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "palette-classic"
-                },
-                "custom": {
-                  "axisBorderShow": false,
-                  "axisCenteredZero": false,
-                  "axisColorMode": "text",
-                  "axisLabel": "",
-                  "axisPlacement": "auto",
-                  "barAlignment": 0,
-                  "barWidthFactor": 0.6,
-                  "drawStyle": "line",
-                  "fillOpacity": 0,
-                  "gradientMode": "none",
-                  "hideFrom": {
-                    "legend": false,
-                    "tooltip": false,
-                    "viz": false
-                  },
-                  "insertNulls": false,
-                  "lineInterpolation": "linear",
-                  "lineWidth": 1,
-                  "pointSize": 5,
-                  "scaleDistribution": {
-                    "type": "linear"
-                  },
-                  "showPoints": "auto",
-                  "showValues": false,
-                  "spanNulls": false,
-                  "stacking": {
-                    "group": "A",
-                    "mode": "none"
-                  },
-                  "thresholdsStyle": {
-                    "mode": "off"
-                  }
-                },
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "percentunit"
-              },
-              "overrides": []
-            },
-            "options": {
-              "annotations": {
-                "clustering": -1,
-                "multiLane": false
-              },
-              "legend": {
-                "calcs": [],
-                "displayMode": "list",
-                "placement": "bottom",
-                "showLegend": true
-              },
-              "tooltip": {
-                "hideZeros": false,
-                "mode": "single",
-                "sort": "none"
-              }
-            }
-          },
-          "version": "13.0.1+security-01"
-        }
-      }
-    },
-    "panel-2": {
-      "kind": "Panel",
-      "spec": {
-        "data": {
-          "kind": "QueryGroup",
-          "spec": {
-            "queries": [
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "expr": "libvirt_domain_info_virtual_cpus{job=\"libvirt_exporter\", domain=~\"$domain\"}",
-                      "instant": false,
-                      "legendFormat": "VM_CPU_Core{{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "A"
-                }
-              },
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "expr": "last_over_time(openstack_placement_resource_total{hostname=~\"$Hypervisor\", resourcetype=~\"PCPU|VCPU\"}[10m])",
-                      "instant": false,
-                      "legendFormat": "Host_CPU_Core{{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "B"
-                }
-              },
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "expr": "min(min_over_time(ipmi_dcmi_power_consumption_watts{instance=~\"$Hypervisor\"}[$__range]))",
-                      "instant": false,
-                      "legendFormat": "Host_Min_Watts{{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "C"
-                }
-              },
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "expr": "max(max_over_time(ipmi_dcmi_power_consumption_watts{instance=~\"$Hypervisor\"}[$__range]))",
-                      "instant": false,
-                      "legendFormat": "Host_Max_Watts{{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "D"
-                }
-              },
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "expr": "rate(libvirt_domain_info_cpu_time_seconds_total{job=\"libvirt_exporter\", domain=~\"$domain\"}[5m])\r\n/\r\non(domain)\r\ngroup_left()\r\nlibvirt_domain_info_virtual_cpus{job=\"libvirt_exporter\"}",
-                      "instant": false,
-                      "legendFormat": "VM_Utilisation{{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "E"
-                }
-              },
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "code",
-                      "expr": "$__range_s / 3600",
-                      "instant": false,
-                      "legendFormat": "Duration(hour){{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "F"
-                }
-              }
-            ],
-            "queryOptions": {},
-            "transformations": [
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "VM_CPU_Core"
-                        }
-                      },
-                      "operator": "/",
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Host_CPU_Core"
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    }
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Host_Max_Watts"
-                        }
-                      },
-                      "operator": "-",
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Host_Min_Watts"
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    }
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "VM_Utilisation"
-                        }
-                      },
-                      "operator": "*",
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Host_Max_Watts - Host_Min_Watts"
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    }
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Host_Min_Watts"
-                        }
-                      },
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "VM_Utilisation * Host_Max_Watts - Host_Min_Watts"
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    }
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "alias": "VM Average Power (W)",
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "VM_CPU_Core / Host_CPU_Core"
-                        }
-                      },
-                      "operator": "*",
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Host_Min_Watts + VM_Utilisation * Host_Max_Watts - Host_Min_Watts"
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    },
-                    "replaceFields": true
-                  }
-                }
-              }
-            ]
-          }
-        },
-        "description": "VM Power = (VM_CPU_core / Host_CPU_core) * [Host_Min_Watts + VM_Utilisation * (Host_Max_Watts - Host_Min_Watts)]",
-        "id": 2,
-        "links": [],
-        "title": "⚡VM Average Power (W)",
-        "vizConfig": {
-          "group": "stat",
-          "kind": "VizConfig",
-          "spec": {
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "thresholds"
-                },
-                "fieldMinMax": false,
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "watt"
-              },
-              "overrides": []
-            },
-            "options": {
-              "colorMode": "none",
-              "graphMode": "none",
-              "justifyMode": "auto",
-              "orientation": "auto",
-              "percentChangeColorMode": "standard",
-              "reduceOptions": {
-                "calcs": [
-                  "lastNotNull"
-                ],
-                "fields": "",
-                "values": false
-              },
-              "showPercentChange": false,
-              "textMode": "auto",
-              "wideLayout": true
-            }
-          },
-          "version": "13.0.2"
-        }
-      }
-    },
-    "panel-20": {
-      "kind": "Panel",
-      "spec": {
-        "data": {
-          "kind": "QueryGroup",
-          "spec": {
-            "queries": [
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "exemplar": false,
-                      "expr": "sum by(instance) (irate(libvirt_domain_info_cpu_time_seconds_total{job=\"libvirt_exporter\", domain=~\"$domain\"}[2m])) * on(instance) libvirt_domain_info_meta{job=\"libvirt_exporter\", uuid=~\"$uuid\"}",
-                      "format": "time_series",
-                      "instant": false,
-                      "interval": "",
-                      "legendFormat": "__auto",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "A"
-                }
-              }
-            ],
-            "queryOptions": {},
-            "transformations": []
-          }
-        },
-        "description": "",
-        "id": 20,
-        "links": [],
-        "title": "Host CPU Utilisation",
-        "vizConfig": {
-          "group": "timeseries",
-          "kind": "VizConfig",
-          "spec": {
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "palette-classic"
-                },
-                "custom": {
-                  "axisBorderShow": false,
-                  "axisCenteredZero": false,
-                  "axisColorMode": "text",
-                  "axisLabel": "",
-                  "axisPlacement": "auto",
-                  "barAlignment": 0,
-                  "barWidthFactor": 0.6,
-                  "drawStyle": "line",
-                  "fillOpacity": 0,
-                  "gradientMode": "none",
-                  "hideFrom": {
-                    "legend": false,
-                    "tooltip": false,
-                    "viz": false
-                  },
-                  "insertNulls": false,
-                  "lineInterpolation": "linear",
-                  "lineWidth": 1,
-                  "pointSize": 5,
-                  "scaleDistribution": {
-                    "type": "linear"
-                  },
-                  "showPoints": "auto",
-                  "showValues": false,
-                  "spanNulls": false,
-                  "stacking": {
-                    "group": "A",
-                    "mode": "none"
-                  },
-                  "thresholdsStyle": {
-                    "mode": "off"
-                  }
-                },
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "none"
-              },
-              "overrides": []
-            },
-            "options": {
-              "annotations": {
-                "clustering": -1,
-                "multiLane": false
-              },
-              "legend": {
-                "calcs": [],
-                "displayMode": "list",
-                "placement": "bottom",
-                "showLegend": true
-              },
-              "tooltip": {
-                "hideZeros": false,
-                "mode": "single",
-                "sort": "none"
-              }
-            }
-          },
-          "version": "13.0.1+security-01"
-        }
-      }
-    },
-    "panel-3": {
-      "kind": "Panel",
-      "spec": {
-        "data": {
-          "kind": "QueryGroup",
-          "spec": {
-            "queries": [
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "expr": "libvirt_domain_info_virtual_cpus{job=\"libvirt_exporter\", domain=~\"$domain\"}",
-                      "instant": false,
-                      "legendFormat": "VM_CPU_Core{{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "A"
-                }
-              },
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "expr": "last_over_time(openstack_placement_resource_total{hostname=~\"$Hypervisor\", resourcetype=~\"PCPU|VCPU\"}[10m])",
-                      "instant": false,
-                      "legendFormat": "Host_CPU_Core{{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "B"
-                }
-              },
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "expr": "min(min_over_time(ipmi_dcmi_power_consumption_watts{instance=~\"$Hypervisor\"}[$__range]))",
-                      "instant": false,
-                      "legendFormat": "Host_Min_Watts{{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "C"
-                }
-              },
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "expr": "max(max_over_time(ipmi_dcmi_power_consumption_watts{instance=~\"$Hypervisor\"}[$__range]))",
-                      "instant": false,
-                      "legendFormat": "Host_Max_Watts{{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "D"
-                }
-              },
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "expr": "rate(libvirt_domain_info_cpu_time_seconds_total{job=\"libvirt_exporter\", domain=~\"$domain\"}[5m])\r\n/\r\non(domain)\r\ngroup_left()\r\nlibvirt_domain_info_virtual_cpus{job=\"libvirt_exporter\"}",
-                      "instant": false,
-                      "legendFormat": "VM_Utilisation{{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "E"
-                }
-              },
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "code",
-                      "expr": "$__range_s / 3600",
-                      "instant": false,
-                      "legendFormat": "Duration(hour){{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "F"
-                }
-              }
-            ],
-            "queryOptions": {},
-            "transformations": [
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "VM_CPU_Core"
-                        }
-                      },
-                      "operator": "/",
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Host_CPU_Core"
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    }
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Host_Max_Watts"
-                        }
-                      },
-                      "operator": "-",
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Host_Min_Watts"
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    }
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "VM_Utilisation"
-                        }
-                      },
-                      "operator": "*",
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Host_Max_Watts - Host_Min_Watts"
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    }
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Host_Min_Watts"
-                        }
-                      },
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "VM_Utilisation * Host_Max_Watts - Host_Min_Watts"
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    }
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "alias": "VM Average Power (W)",
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "VM_CPU_Core / Host_CPU_Core"
-                        }
-                      },
-                      "operator": "*",
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Host_Min_Watts + VM_Utilisation * Host_Max_Watts - Host_Min_Watts"
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    },
-                    "replaceFields": false
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "alias": "Total VM Energy (Wh)",
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "VM Average Power (W)"
-                        }
-                      },
-                      "operator": "*",
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Duration(hour)"
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    }
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "alias": "PUE",
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Total VM Energy (Wh)"
-                        }
-                      },
-                      "operator": "*",
-                      "right": {
-                        "fixed": "1.3"
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    },
-                    "replaceFields": true
-                  }
-                }
-              }
-            ]
-          }
-        },
-        "description": "VM Power = (VM_CPU_core / Host_CPU_core) * [Host_Min_Watts + VM_Utilisation * (Host_Max_Watts - Host_Min_Watts)]",
-        "id": 3,
-        "links": [],
-        "title": "⚡VM Total Energy Used (Wh)",
-        "vizConfig": {
-          "group": "stat",
-          "kind": "VizConfig",
-          "spec": {
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "thresholds"
-                },
-                "fieldMinMax": false,
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "watth"
-              },
-              "overrides": []
-            },
-            "options": {
-              "colorMode": "none",
-              "graphMode": "none",
-              "justifyMode": "auto",
-              "orientation": "auto",
-              "percentChangeColorMode": "standard",
-              "reduceOptions": {
-                "calcs": [
-                  "lastNotNull"
-                ],
-                "fields": "",
-                "values": false
-              },
-              "showPercentChange": false,
-              "textMode": "auto",
-              "wideLayout": true
-            }
-          },
-          "version": "13.0.2"
-        }
-      }
-    },
-    "panel-4": {
-      "kind": "Panel",
-      "spec": {
-        "data": {
-          "kind": "QueryGroup",
-          "spec": {
-            "queries": [
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "code",
-                      "expr": "$__range_s / 3600",
-                      "instant": false,
-                      "legendFormat": "__auto",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "A"
-                }
-              }
-            ],
-            "queryOptions": {},
-            "transformations": []
-          }
-        },
-        "description": "",
-        "id": 4,
-        "links": [],
-        "title": "Duration",
-        "vizConfig": {
-          "group": "stat",
-          "kind": "VizConfig",
-          "spec": {
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "palette-classic"
-                },
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "h"
-              },
-              "overrides": []
-            },
-            "options": {
-              "colorMode": "value",
-              "graphMode": "none",
-              "justifyMode": "auto",
-              "orientation": "auto",
-              "percentChangeColorMode": "standard",
-              "reduceOptions": {
-                "calcs": [
-                  "lastNotNull"
-                ],
-                "fields": "",
-                "values": false
-              },
-              "showPercentChange": false,
-              "textMode": "auto",
-              "wideLayout": true
-            }
-          },
-          "version": "13.0.2"
-        }
-      }
-    },
-    "panel-5": {
-      "kind": "Panel",
-      "spec": {
-        "data": {
-          "kind": "QueryGroup",
-          "spec": {
-            "queries": [
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "expr": "libvirt_domain_info_virtual_cpus{job=\"libvirt_exporter\", domain=~\"$domain\"}",
-                      "instant": false,
-                      "legendFormat": "VM_CPU_Core{{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "A"
-                }
-              },
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "expr": "last_over_time(openstack_placement_resource_total{hostname=~\"$Hypervisor\", resourcetype=~\"PCPU|VCPU\"}[10m])",
-                      "instant": false,
-                      "legendFormat": "Host_CPU_Core{{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "B"
-                }
-              },
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "expr": "min(min_over_time(ipmi_dcmi_power_consumption_watts{instance=~\"$Hypervisor\"}[$__range]))",
-                      "instant": false,
-                      "legendFormat": "Host_Min_Watts{{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "C"
-                }
-              },
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "expr": "max(max_over_time(ipmi_dcmi_power_consumption_watts{instance=~\"$Hypervisor\"}[$__range]))",
-                      "instant": false,
-                      "legendFormat": "Host_Max_Watts{{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "D"
-                }
-              },
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "expr": "rate(libvirt_domain_info_cpu_time_seconds_total{job=\"libvirt_exporter\", domain=~\"$domain\"}[5m])\r\n/\r\non(domain)\r\ngroup_left()\r\nlibvirt_domain_info_virtual_cpus{job=\"libvirt_exporter\"}",
-                      "instant": false,
-                      "legendFormat": "VM_Utilisation{{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "E"
-                }
-              },
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "code",
-                      "expr": "$__range_s / 3600",
-                      "instant": false,
-                      "legendFormat": "Duration(hour){{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "F"
-                }
-              }
-            ],
-            "queryOptions": {},
-            "transformations": [
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "VM_CPU_Core"
-                        }
-                      },
-                      "operator": "/",
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Host_CPU_Core"
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    }
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Host_Max_Watts"
-                        }
-                      },
-                      "operator": "-",
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Host_Min_Watts"
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    }
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "VM_Utilisation"
-                        }
-                      },
-                      "operator": "*",
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Host_Max_Watts - Host_Min_Watts"
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    }
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Host_Min_Watts"
-                        }
-                      },
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "VM_Utilisation * Host_Max_Watts - Host_Min_Watts"
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    }
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "alias": "VM Average Power (W)",
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "VM_CPU_Core / Host_CPU_Core"
-                        }
-                      },
-                      "operator": "*",
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Host_Min_Watts + VM_Utilisation * Host_Max_Watts - Host_Min_Watts"
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    },
-                    "replaceFields": false
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "alias": "pue",
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "VM Average Power (W)"
-                        }
-                      },
-                      "operator": "*",
-                      "right": {
-                        "fixed": "1.3"
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    }
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "alias": "VM Average Power (kW)",
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "pue"
-                        }
-                      },
-                      "operator": "/",
-                      "right": {
-                        "fixed": "1000"
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    }
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "VM Average Power (kW)"
-                        }
-                      },
-                      "operator": "*",
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "$carbon_intensity"
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    },
-                    "replaceFields": true
-                  }
-                }
-              }
-            ]
-          }
-        },
-        "description": "UK average carbon intensity in 2025 is 126 gCO2/kWh. <br>\nSource: <br>\nhttps://www.carbonbrief.org/analysis-uk-renewables-enjoy-record-year-in-2025-but-gas-power-still-rises/ <br>\nhttps://www.energydashboard.co.uk/insights/2025-review",
-        "id": 5,
-        "links": [],
-        "title": "🌍 Carbon Emission of VM per Hour (gCO2)",
-        "vizConfig": {
-          "group": "stat",
-          "kind": "VizConfig",
-          "spec": {
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "thresholds"
-                },
-                "fieldMinMax": false,
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "massg"
-              },
-              "overrides": []
-            },
-            "options": {
-              "colorMode": "none",
-              "graphMode": "none",
-              "justifyMode": "auto",
-              "orientation": "auto",
-              "percentChangeColorMode": "standard",
-              "reduceOptions": {
-                "calcs": [
-                  "lastNotNull"
-                ],
-                "fields": "",
-                "values": false
-              },
-              "showPercentChange": false,
-              "textMode": "auto",
-              "wideLayout": true
-            }
-          },
-          "version": "13.0.2"
-        }
-      }
-    },
-    "panel-6": {
-      "kind": "Panel",
-      "spec": {
-        "data": {
-          "kind": "QueryGroup",
-          "spec": {
-            "queries": [
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "expr": "libvirt_domain_info_virtual_cpus{job=\"libvirt_exporter\", domain=~\"$domain\"}",
-                      "instant": false,
-                      "legendFormat": "VM_CPU_Core{{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "A"
-                }
-              },
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "expr": "last_over_time(openstack_placement_resource_total{hostname=~\"$Hypervisor\", resourcetype=~\"PCPU|VCPU\"}[10m])",
-                      "instant": false,
-                      "legendFormat": "Host_CPU_Core{{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "B"
-                }
-              },
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "expr": "min(min_over_time(ipmi_dcmi_power_consumption_watts{instance=~\"$Hypervisor\"}[$__range]))",
-                      "instant": false,
-                      "legendFormat": "Host_Min_Watts{{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "C"
-                }
-              },
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "expr": "max(max_over_time(ipmi_dcmi_power_consumption_watts{instance=~\"$Hypervisor\"}[$__range]))",
-                      "instant": false,
-                      "legendFormat": "Host_Max_Watts{{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "D"
-                }
-              },
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "expr": "rate(libvirt_domain_info_cpu_time_seconds_total{job=\"libvirt_exporter\", domain=~\"$domain\"}[5m])\r\n/\r\non(domain)\r\ngroup_left()\r\nlibvirt_domain_info_virtual_cpus{job=\"libvirt_exporter\"}",
-                      "instant": false,
-                      "legendFormat": "VM_Utilisation{{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "E"
-                }
-              },
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "code",
-                      "expr": "$__range_s / 3600",
-                      "instant": false,
-                      "legendFormat": "Duration(hour){{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "F"
-                }
-              }
-            ],
-            "queryOptions": {},
-            "transformations": [
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "VM_CPU_Core"
-                        }
-                      },
-                      "operator": "/",
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Host_CPU_Core"
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    }
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Host_Max_Watts"
-                        }
-                      },
-                      "operator": "-",
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Host_Min_Watts"
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    }
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "VM_Utilisation"
-                        }
-                      },
-                      "operator": "*",
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Host_Max_Watts - Host_Min_Watts"
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    }
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Host_Min_Watts"
-                        }
-                      },
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "VM_Utilisation * Host_Max_Watts - Host_Min_Watts"
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    }
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "alias": "VM Average Power (W)",
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "VM_CPU_Core / Host_CPU_Core"
-                        }
-                      },
-                      "operator": "*",
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Host_Min_Watts + VM_Utilisation * Host_Max_Watts - Host_Min_Watts"
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    },
-                    "replaceFields": false
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "alias": "Total VM Energy (Wh)",
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "VM Average Power (W)"
-                        }
-                      },
-                      "operator": "*",
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Duration(hour)"
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    }
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "alias": "PUE",
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Total VM Energy (Wh)"
-                        }
-                      },
-                      "operator": "*",
-                      "right": {
-                        "fixed": "1.3"
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    },
-                    "replaceFields": false
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "alias": "Total VM Energy (Wh)",
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "PUE"
-                        }
-                      },
-                      "operator": "*",
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Duration(hour)"
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    }
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "alias": "Total VM Energy (kWh)",
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Total VM Energy (Wh)"
-                        }
-                      },
-                      "operator": "/",
-                      "right": {
-                        "fixed": "1000"
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    }
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Total VM Energy (kWh)"
-                        }
-                      },
-                      "operator": "*",
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "$carbon_intensity"
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    },
-                    "replaceFields": true
-                  }
-                }
-              }
-            ]
-          }
-        },
-        "description": "UK average carbon intensity in 2025 is 126 gCO2/kWh. <br>\nSource: <br>\nhttps://www.carbonbrief.org/analysis-uk-renewables-enjoy-record-year-in-2025-but-gas-power-still-rises/ <br>\nhttps://www.energydashboard.co.uk/insights/2025-review",
-        "id": 6,
-        "links": [],
-        "title": "🌍 Total Carbon Emission (gCO2)",
-        "vizConfig": {
-          "group": "stat",
-          "kind": "VizConfig",
-          "spec": {
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "thresholds"
-                },
-                "fieldMinMax": false,
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "massg"
-              },
-              "overrides": []
-            },
-            "options": {
-              "colorMode": "none",
-              "graphMode": "none",
-              "justifyMode": "auto",
-              "orientation": "auto",
-              "percentChangeColorMode": "standard",
-              "reduceOptions": {
-                "calcs": [
-                  "lastNotNull"
-                ],
-                "fields": "",
-                "values": false
-              },
-              "showPercentChange": false,
-              "textMode": "auto",
-              "wideLayout": true
-            }
-          },
-          "version": "13.0.2"
-        }
-      }
-    },
-    "panel-7": {
-      "kind": "Panel",
-      "spec": {
-        "data": {
-          "kind": "QueryGroup",
-          "spec": {
-            "queries": [
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "expr": "libvirt_domain_info_virtual_cpus{job=\"libvirt_exporter\", domain=~\"$domain\"}",
-                      "instant": false,
-                      "legendFormat": "VM_CPU_Core{{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "A"
-                }
-              },
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "expr": "last_over_time(openstack_placement_resource_total{hostname=~\"$Hypervisor\", resourcetype=~\"PCPU|VCPU\"}[10m])",
-                      "instant": false,
-                      "legendFormat": "Host_CPU_Core{{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "B"
-                }
-              },
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "expr": "min(min_over_time(ipmi_dcmi_power_consumption_watts{instance=~\"$Hypervisor\"}[$__range]))",
-                      "instant": false,
-                      "legendFormat": "Host_Min_Watts{{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "C"
-                }
-              },
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "expr": "max(max_over_time(ipmi_dcmi_power_consumption_watts{instance=~\"$Hypervisor\"}[$__range]))",
-                      "instant": false,
-                      "legendFormat": "Host_Max_Watts{{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "D"
-                }
-              },
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "expr": "rate(libvirt_domain_info_cpu_time_seconds_total{job=\"libvirt_exporter\", domain=~\"$domain\"}[5m])\r\n/\r\non(domain)\r\ngroup_left()\r\nlibvirt_domain_info_virtual_cpus{job=\"libvirt_exporter\"}",
-                      "instant": false,
-                      "legendFormat": "VM_Utilisation{{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "E"
-                }
-              },
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "code",
-                      "expr": "$__range_s / 3600",
-                      "instant": false,
-                      "legendFormat": "Duration(hour){{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "F"
-                }
-              }
-            ],
-            "queryOptions": {},
-            "transformations": [
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "VM_CPU_Core"
-                        }
-                      },
-                      "operator": "/",
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Host_CPU_Core"
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    }
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Host_Max_Watts"
-                        }
-                      },
-                      "operator": "-",
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Host_Min_Watts"
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    }
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "VM_Utilisation"
-                        }
-                      },
-                      "operator": "*",
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Host_Max_Watts - Host_Min_Watts"
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    }
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Host_Min_Watts"
-                        }
-                      },
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "VM_Utilisation * Host_Max_Watts - Host_Min_Watts"
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    }
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "alias": "VM Average Power (W)",
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "VM_CPU_Core / Host_CPU_Core"
-                        }
-                      },
-                      "operator": "*",
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Host_Min_Watts + VM_Utilisation * Host_Max_Watts - Host_Min_Watts"
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    },
-                    "replaceFields": false
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "alias": "Total VM Energy (Wh)",
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "VM Average Power (W)"
-                        }
-                      },
-                      "operator": "*",
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Duration(hour)"
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    }
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "alias": "Total VM Energy (kWh)",
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Total VM Energy (Wh)"
-                        }
-                      },
-                      "operator": "/",
-                      "right": {
-                        "fixed": "1000"
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    },
-                    "replaceFields": false
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "alias": "Total VM Energy (kWh) * PUE",
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Total VM Energy (kWh)"
-                        }
-                      },
-                      "operator": "*",
-                      "right": {
-                        "fixed": "1.3"
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    }
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "alias": "Price",
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Total VM Energy (kWh) * PUE"
-                        }
-                      },
-                      "operator": "*",
-                      "right": {
-                        "fixed": "0.21"
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    },
-                    "replaceFields": true
-                  }
-                }
-              }
-            ]
-          }
-        },
-        "description": "As of 17th March 2026 <br>\nAverage electricity cost report by HPC Operation Costing Report is £0.21 per kWh. <br>\nElectricity Cost = Total Energy * 0.21 <br>\nSource: <br>\nhttp://cacti-master-virt.di.stfc.ac.uk/Information/CostingForm.php",
-        "id": 7,
-        "links": [],
-        "title": "£ VM Energy Cost",
-        "vizConfig": {
-          "group": "stat",
-          "kind": "VizConfig",
-          "spec": {
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "thresholds"
-                },
-                "fieldMinMax": false,
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "currencyGBP"
-              },
-              "overrides": []
-            },
-            "options": {
-              "colorMode": "none",
-              "graphMode": "none",
-              "justifyMode": "auto",
-              "orientation": "auto",
-              "percentChangeColorMode": "standard",
-              "reduceOptions": {
-                "calcs": [
-                  "lastNotNull"
-                ],
-                "fields": "",
-                "values": false
-              },
-              "showPercentChange": false,
-              "textMode": "auto",
-              "wideLayout": true
-            }
-          },
-          "version": "13.0.2"
-        }
-      }
-    },
-    "panel-8": {
-      "kind": "Panel",
-      "spec": {
-        "data": {
-          "kind": "QueryGroup",
-          "spec": {
-            "queries": [],
-            "queryOptions": {},
-            "transformations": []
-          }
-        },
-        "description": "",
-        "id": 8,
-        "links": [],
-        "title": "",
-        "vizConfig": {
-          "group": "text",
-          "kind": "VizConfig",
-          "spec": {
-            "fieldConfig": {
-              "defaults": {},
-              "overrides": []
-            },
-            "options": {
-              "code": {
-                "language": "plaintext",
-                "showLineNumbers": false,
-                "showMiniMap": false
-              },
-              "content": "# ⚡Virtual Machine Power & Carbon Emissions Dashboard Method 2\nThis dashboard estimates the **power consumption** and **carbon emissions** of an OpenStack Virtual Machine (VM) over a selected time period.<br>\nThe calculation is based on the VM’s allocated CPU cores and its utilisation relative to the host’s power profile.\n> ⚠️ The results represent an **approximation**, not an exact measurement of VM energy usage.<br>\n> ⚠️ This dashboard supports Compute (CPU) flavours only.<br>\n`GPU flavours are not supported and may produce incorrect estimates.`\n\n## 🧭 How to Use This Dashboard\n\n1. **Select your VM Instance Name:**<br>\nUse the Instance Name dropdown at the top of the dashboard to select your VM.<br>\n2. **Handle duplicate VM names (if applicable):**<br>\n-If multiple VMs share the same name:<br>\n-Go to: https://openstack.stfc.ac.uk<br>\n-Navigate to: Project → Instances<br>\n-Find the correct VM and copy its Instance ID (UUID)<br>\n-In Grafana, after selecting the instance name, choose the corresponding VM UUID from the UUID variable dropdown<br>\n5. **Select the time range:**<br>\nChoose the time period you want to analyse using the time picker.<br>\n6. **View the Results, the dashboard will display:**<br>\nEstimated VM power consumption<br>\nEstimated carbon emissions\n\n## 🧮 Calculation Method\nThe VM power consumption is estimated based on:<br>\n- How much of the host machine your VM is allocated (CPU cores)<br>\n- How actively your VM is using those CPU resources (utilisation)<br>\n- How the host server’s power changes between idle and full load<br>\n\n📐 Formula: `Average Watts = Min Watts + Avg vCPU Utilization * (Max Watts - Min Watts)`<br>\nSource: https://www.cloudcarbonfootprint.org/docs/methodology<br>\nImplemented equation: `VM Power ≈ (VM CPU Cores / Host CPU Cores) × [Host Min Power + VM Utilisation × (Host Max Power − Host Min Power)]`<br>\n\n\n## ⚠️ Important Limitations\nThe VM power attribution is calculated only from CPU resources and does not include:<br>\n- Memory (RAM) usage\n- Disk storage and I/O activity\n- Network traffic\n- GPU or accelerator usage<br>\n\nWorkloads that rely heavily on these resources may therefore have their actual energy usage under- or over-estimated.<br>\nTherefore, this dashboard currently supports only Compute (CPU) flavours.<br>\nGPU flavours are not supported and will not produce accurate power or carbon estimates.\n## 🌱 Purpose of This Dashboard:\nThis dashboard helps users:\n- Understand the energy footprint of their virtual machines.\n- Estimate carbon emissions of workloads\n- Support sustainability and energy awareness in using STFC Cloud",
-              "mode": "markdown"
-            }
-          },
-          "version": "13.0.2"
-        }
-      }
-    },
-    "panel-9": {
-      "kind": "Panel",
-      "spec": {
-        "data": {
-          "kind": "QueryGroup",
-          "spec": {
-            "queries": [
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "expr": "libvirt_domain_info_virtual_cpus{job=\"libvirt_exporter\", domain=~\"$domain\"}",
-                      "instant": false,
-                      "legendFormat": "VM_CPU_Core{{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "A"
-                }
-              },
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "expr": "last_over_time(openstack_placement_resource_total{hostname=~\"$Hypervisor\", resourcetype=~\"PCPU|VCPU\"}[10m])",
-                      "instant": false,
-                      "legendFormat": "Host_CPU_Core{{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "B"
-                }
-              },
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "expr": "min(min_over_time(ipmi_dcmi_power_consumption_watts{instance=~\"$Hypervisor\"}[$__range]))",
-                      "instant": false,
-                      "legendFormat": "Host_Min_Watts{{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "C"
-                }
-              },
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "expr": "max(max_over_time(ipmi_dcmi_power_consumption_watts{instance=~\"$Hypervisor\"}[$__range]))",
-                      "instant": false,
-                      "legendFormat": "Host_Max_Watts{{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "D"
-                }
-              },
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "builder",
-                      "expr": "rate(libvirt_domain_info_cpu_time_seconds_total{job=\"libvirt_exporter\", domain=~\"$domain\"}[5m])\r\n/\r\non(domain)\r\ngroup_left()\r\nlibvirt_domain_info_virtual_cpus{job=\"libvirt_exporter\"}",
-                      "instant": false,
-                      "legendFormat": "VM_Utilisation{{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "E"
-                }
-              },
-              {
-                "kind": "PanelQuery",
-                "spec": {
-                  "hidden": false,
-                  "query": {
-                    "datasource": {
-                      "name": "remote_write_prometheus"
-                    },
-                    "group": "prometheus",
-                    "kind": "DataQuery",
-                    "spec": {
-                      "editorMode": "code",
-                      "expr": "$__range_s / 3600",
-                      "instant": false,
-                      "legendFormat": "Duration(hour){{label_name}}",
-                      "range": true
-                    },
-                    "version": "v0"
-                  },
-                  "refId": "F"
-                }
-              }
-            ],
-            "queryOptions": {},
-            "transformations": [
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "VM_CPU_Core"
-                        }
-                      },
-                      "operator": "/",
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Host_CPU_Core"
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    }
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Host_Max_Watts"
-                        }
-                      },
-                      "operator": "-",
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Host_Min_Watts"
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    }
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "VM_Utilisation"
-                        }
-                      },
-                      "operator": "*",
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Host_Max_Watts - Host_Min_Watts"
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    }
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Host_Min_Watts"
-                        }
-                      },
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "VM_Utilisation * Host_Max_Watts - Host_Min_Watts"
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    }
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "alias": "VM Average Power (W)",
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "VM_CPU_Core / Host_CPU_Core"
-                        }
-                      },
-                      "operator": "*",
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Host_Min_Watts + VM_Utilisation * Host_Max_Watts - Host_Min_Watts"
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    },
-                    "replaceFields": false
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "alias": "Total VM Energy (Wh)",
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "VM Average Power (W)"
-                        }
-                      },
-                      "operator": "*",
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Duration(hour)"
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    }
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "alias": "PUE",
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Total VM Energy (Wh)"
-                        }
-                      },
-                      "operator": "*",
-                      "right": {
-                        "fixed": "1.3"
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    },
-                    "replaceFields": false
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "alias": "Total VM Energy (Wh)",
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "PUE"
-                        }
-                      },
-                      "operator": "*",
-                      "right": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Duration(hour)"
-                        }
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    }
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "alias": "Total VM Energy (kWh)",
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Total VM Energy (Wh)"
-                        }
-                      },
-                      "operator": "/",
-                      "right": {
-                        "fixed": "1000"
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    }
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "alias": "gCO2",
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "Total VM Energy (kWh)"
-                        }
-                      },
-                      "operator": "*",
-                      "right": {
-                        "fixed": "126"
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    },
-                    "replaceFields": false
-                  }
-                }
-              },
-              {
-                "group": "calculateField",
-                "kind": "Transformation",
-                "spec": {
-                  "options": {
-                    "alias": "Car",
-                    "binary": {
-                      "left": {
-                        "matcher": {
-                          "id": "byName",
-                          "options": "gCO2"
-                        }
-                      },
-                      "operator": "/",
-                      "right": {
-                        "fixed": "7150"
-                      }
-                    },
-                    "mode": "binary",
-                    "reduce": {
-                      "reducer": "sum"
-                    },
-                    "replaceFields": true
-                  }
-                }
-              }
-            ]
-          }
-        },
-        "description": "Petrol cars had 143 gCO2/km\n=> 7150 gCO2 per hour driving (assuming 50km/h or 30mph)\nSource: 2022 UK GOV (https://www.gov.uk/government/statistics/vehicle-licensing-statistics-2022/vehicle-licensing-statistics-2022#carbon-co2-emissions-for-new-vehicle-registrations)",
-        "id": 9,
-        "links": [],
-        "title": "🚗 Driving a Petrol Car for",
-        "vizConfig": {
-          "group": "stat",
-          "kind": "VizConfig",
-          "spec": {
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "thresholds"
-                },
-                "decimals": 2,
-                "fieldMinMax": false,
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "h"
-              },
-              "overrides": []
-            },
-            "options": {
-              "colorMode": "none",
-              "graphMode": "none",
-              "justifyMode": "auto",
-              "orientation": "auto",
-              "percentChangeColorMode": "standard",
-              "reduceOptions": {
-                "calcs": [
-                  "lastNotNull"
-                ],
-                "fields": "",
-                "values": false
-              },
-              "showPercentChange": false,
-              "textMode": "auto",
-              "wideLayout": true
-            }
-          },
-          "version": "13.0.2"
-        }
-      }
-    }
-  },
-  "layout": {
-    "kind": "RowsLayout",
-    "spec": {
-      "rows": [
-        {
-          "kind": "RowsLayoutRow",
-          "spec": {
-            "collapse": false,
-            "layout": {
-              "kind": "GridLayout",
-              "spec": {
-                "items": [
-                  {
-                    "kind": "GridLayoutItem",
-                    "spec": {
-                      "element": {
-                        "kind": "ElementReference",
-                        "name": "panel-8"
-                      },
-                      "height": 18,
-                      "width": 18,
-                      "x": 0,
-                      "y": 0
-                    }
-                  },
-                  {
-                    "kind": "GridLayoutItem",
-                    "spec": {
-                      "element": {
-                        "kind": "ElementReference",
-                        "name": "panel-4"
-                      },
-                      "height": 3,
-                      "width": 6,
-                      "x": 18,
-                      "y": 0
-                    }
-                  },
-                  {
-                    "kind": "GridLayoutItem",
-                    "spec": {
-                      "element": {
-                        "kind": "ElementReference",
-                        "name": "panel-6"
-                      },
-                      "height": 3,
-                      "width": 6,
-                      "x": 18,
-                      "y": 3
-                    }
-                  },
-                  {
-                    "kind": "GridLayoutItem",
-                    "spec": {
-                      "element": {
-                        "kind": "ElementReference",
-                        "name": "panel-5"
-                      },
-                      "height": 3,
-                      "width": 6,
-                      "x": 18,
-                      "y": 6
-                    }
-                  },
-                  {
-                    "kind": "GridLayoutItem",
-                    "spec": {
-                      "element": {
-                        "kind": "ElementReference",
-                        "name": "panel-2"
-                      },
-                      "height": 3,
-                      "width": 6,
-                      "x": 18,
-                      "y": 9
-                    }
-                  },
-                  {
-                    "kind": "GridLayoutItem",
-                    "spec": {
-                      "element": {
-                        "kind": "ElementReference",
-                        "name": "panel-3"
-                      },
-                      "height": 3,
-                      "width": 6,
-                      "x": 18,
-                      "y": 12
-                    }
-                  },
-                  {
-                    "kind": "GridLayoutItem",
-                    "spec": {
-                      "element": {
-                        "kind": "ElementReference",
-                        "name": "panel-7"
-                      },
-                      "height": 3,
-                      "width": 6,
-                      "x": 18,
-                      "y": 15
-                    }
-                  },
-                  {
-                    "kind": "GridLayoutItem",
-                    "spec": {
-                      "element": {
-                        "kind": "ElementReference",
-                        "name": "panel-9"
-                      },
-                      "height": 4,
-                      "width": 6,
-                      "x": 0,
-                      "y": 18
-                    }
-                  },
-                  {
-                    "kind": "GridLayoutItem",
-                    "spec": {
-                      "element": {
-                        "kind": "ElementReference",
-                        "name": "panel-10"
-                      },
-                      "height": 4,
-                      "width": 6,
-                      "x": 6,
-                      "y": 18
-                    }
-                  },
-                  {
-                    "kind": "GridLayoutItem",
-                    "spec": {
-                      "element": {
-                        "kind": "ElementReference",
-                        "name": "panel-1"
-                      },
-                      "height": 8,
-                      "width": 24,
-                      "x": 0,
-                      "y": 22
-                    }
-                  }
-                ]
-              }
-            },
-            "title": "Main"
-          }
-        },
-        {
-          "kind": "RowsLayoutRow",
-          "spec": {
-            "collapse": false,
-            "layout": {
-              "kind": "GridLayout",
-              "spec": {
-                "items": [
-                  {
-                    "kind": "GridLayoutItem",
-                    "spec": {
-                      "element": {
-                        "kind": "ElementReference",
-                        "name": "panel-11"
-                      },
-                      "height": 3,
-                      "width": 6,
-                      "x": 0,
-                      "y": 0
-                    }
-                  },
-                  {
-                    "kind": "GridLayoutItem",
-                    "spec": {
-                      "element": {
-                        "kind": "ElementReference",
-                        "name": "panel-12"
-                      },
-                      "height": 3,
-                      "width": 4,
-                      "x": 6,
-                      "y": 0
-                    }
-                  },
-                  {
-                    "kind": "GridLayoutItem",
-                    "spec": {
-                      "element": {
-                        "kind": "ElementReference",
-                        "name": "panel-14"
-                      },
-                      "height": 3,
-                      "width": 6,
-                      "x": 10,
-                      "y": 0
-                    }
-                  },
-                  {
-                    "kind": "GridLayoutItem",
-                    "spec": {
-                      "element": {
-                        "kind": "ElementReference",
-                        "name": "panel-13"
-                      },
-                      "height": 3,
-                      "width": 6,
-                      "x": 16,
-                      "y": 0
-                    }
-                  },
-                  {
-                    "kind": "GridLayoutItem",
-                    "spec": {
-                      "element": {
-                        "kind": "ElementReference",
-                        "name": "panel-15"
-                      },
-                      "height": 6,
-                      "width": 3,
-                      "x": 0,
-                      "y": 3
-                    }
-                  },
-                  {
-                    "kind": "GridLayoutItem",
-                    "spec": {
-                      "element": {
-                        "kind": "ElementReference",
-                        "name": "panel-16"
-                      },
-                      "height": 6,
-                      "width": 3,
-                      "x": 3,
-                      "y": 3
-                    }
-                  },
-                  {
-                    "kind": "GridLayoutItem",
-                    "spec": {
-                      "element": {
-                        "kind": "ElementReference",
-                        "name": "panel-17"
-                      },
-                      "height": 6,
-                      "width": 3,
-                      "x": 6,
-                      "y": 3
-                    }
-                  },
-                  {
-                    "kind": "GridLayoutItem",
-                    "spec": {
-                      "element": {
-                        "kind": "ElementReference",
-                        "name": "panel-18"
-                      },
-                      "height": 6,
-                      "width": 3,
-                      "x": 9,
-                      "y": 3
-                    }
-                  },
-                  {
-                    "kind": "GridLayoutItem",
-                    "spec": {
-                      "element": {
-                        "kind": "ElementReference",
-                        "name": "panel-19"
-                      },
-                      "height": 6,
-                      "width": 3,
-                      "x": 12,
-                      "y": 3
-                    }
-                  },
-                  {
-                    "kind": "GridLayoutItem",
-                    "spec": {
-                      "element": {
-                        "kind": "ElementReference",
-                        "name": "panel-20"
-                      },
-                      "height": 6,
-                      "width": 3,
-                      "x": 15,
-                      "y": 3
-                    }
-                  }
-                ]
-              }
-            },
-            "title": "Host & VM Metrics"
-          }
-        }
-      ]
-    }
-  },
-  "links": [],
-  "liveNow": false,
-  "preferences": {
-    "layout": {
-      "kind": "GridLayout",
-      "spec": {
-        "items": []
-      }
-    }
-  },
   "preload": false,
-  "tags": [],
-  "timeSettings": {
-    "autoRefresh": "",
-    "autoRefreshIntervals": [
+  "refresh": "",
+  "schemaVersion": 42,
+  "templating": {
+    "list": [
+      {
+        "allowCustomValue": true,
+        "current": {
+          "text": "RemoteWritePrometheus",
+          "value": "remote_write_prometheus"
+        },
+        "description": "The prometheus datasource used for queries.",
+        "hide": 0,
+        "includeAll": false,
+        "label": "datasource",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "RemoteWritePrometheus",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "allowCustomValue": true,
+        "current": {
+          "text": "AI4S",
+          "value": "AI4S"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "remote_write_prometheus"
+        },
+        "definition": "label_values(libvirt_domain_info_meta,instance_name)",
+        "description": "Name of your Virtual Machine instance as created on STFC Cloud OpenStack",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Virtual Machine Name",
+        "multi": false,
+        "name": "instance_name",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(libvirt_domain_info_meta,instance_name)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "regexApplyTo": "value",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "allowCustomValue": true,
+        "current": {
+          "text": "c3d23176-236b-4165-8aa4-33232ce21118",
+          "value": "c3d23176-236b-4165-8aa4-33232ce21118"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "remote_write_prometheus"
+        },
+        "definition": "label_values(libvirt_domain_info_meta{job=\"libvirt_exporter\", instance_name=~\"$instance_name\"},uuid)",
+        "description": "Virtual Machine UUID from STFC Cloud OpenStack",
+        "hide": 0,
+        "includeAll": false,
+        "label": "VM uuid",
+        "multi": false,
+        "name": "uuid",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(libvirt_domain_info_meta{job=\"libvirt_exporter\", instance_name=~\"$instance_name\"},uuid)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "regexApplyTo": "value",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "allowCustomValue": true,
+        "current": {
+          "text": "hv-a100x8-6.nubes.rl.ac.uk",
+          "value": "hv-a100x8-6.nubes.rl.ac.uk"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "remote_write_prometheus"
+        },
+        "definition": "label_values(libvirt_domain_info_meta{job=\"libvirt_exporter\", uuid=~\"$uuid\"},instance)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Hypervisor",
+        "multi": false,
+        "name": "Hypervisor",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(libvirt_domain_info_meta{job=\"libvirt_exporter\", uuid=~\"$uuid\"},instance)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "regexApplyTo": "value",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allowCustomValue": false,
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "remote_write_prometheus"
+        },
+        "definition": "label_values(libvirt_domain_info_meta{job=\"libvirt_exporter\", instance_name=~\"$instance_name\"},domain)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Domain",
+        "multi": false,
+        "name": "domain",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(libvirt_domain_info_meta{job=\"libvirt_exporter\", instance_name=~\"$instance_name\"},domain)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "regexApplyTo": "value",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {
+          "text": "126",
+          "value": "126"
+        },
+        "description": "",
+        "hide": 2,
+        "label": "",
+        "name": "carbon_intensity",
+        "query": "126",
+        "skipUrlSync": true,
+        "type": "constant"
+      },
+      {
+        "current": {
+          "text": "1.3",
+          "value": "1.3"
+        },
+        "hide": 2,
+        "name": "pue",
+        "query": "1.3",
+        "skipUrlSync": true,
+        "type": "constant"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-12h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
       "5s",
       "10s",
       "30s",
@@ -4908,205 +3846,11 @@
       "1h",
       "2h",
       "1d"
-    ],
-    "fiscalYearStartMonth": 0,
-    "from": "now-12h",
-    "hideTimepicker": false,
-    "timezone": "browser",
-    "to": "now"
+    ]
   },
+  "timezone": "browser",
   "title": "VM Power & Carbon Method 2",
-  "variables": [
-    {
-      "kind": "DatasourceVariable",
-      "spec": {
-        "allowCustomValue": true,
-        "current": {
-          "text": "RemoteWritePrometheus",
-          "value": "remote_write_prometheus"
-        },
-        "description": "The prometheus datasource used for queries.",
-        "hide": "dontHide",
-        "includeAll": false,
-        "label": "datasource",
-        "multi": false,
-        "name": "datasource",
-        "options": [],
-        "pluginId": "prometheus",
-        "refresh": "onDashboardLoad",
-        "regex": "RemoteWritePrometheus",
-        "skipUrlSync": false
-      }
-    },
-    {
-      "kind": "QueryVariable",
-      "spec": {
-        "allowCustomValue": true,
-        "current": {
-          "text": "AI4S",
-          "value": "AI4S"
-        },
-        "definition": "label_values(libvirt_domain_info_meta,instance_name)",
-        "description": "Name of your Virtual Machine instance as created on STFC Cloud OpenStack",
-        "hide": "dontHide",
-        "includeAll": false,
-        "label": "Virtual Machine Name",
-        "multi": false,
-        "name": "instance_name",
-        "options": [],
-        "query": {
-          "datasource": {
-            "name": "remote_write_prometheus"
-          },
-          "group": "prometheus",
-          "kind": "DataQuery",
-          "spec": {
-            "qryType": 1,
-            "query": "label_values(libvirt_domain_info_meta,instance_name)",
-            "refId": "PrometheusVariableQueryEditor-VariableQuery"
-          },
-          "version": "v0"
-        },
-        "refresh": "onDashboardLoad",
-        "regex": "",
-        "regexApplyTo": "value",
-        "skipUrlSync": false,
-        "sort": "disabled"
-      }
-    },
-    {
-      "kind": "QueryVariable",
-      "spec": {
-        "allowCustomValue": true,
-        "current": {
-          "text": "c3d23176-236b-4165-8aa4-33232ce21118",
-          "value": "c3d23176-236b-4165-8aa4-33232ce21118"
-        },
-        "definition": "label_values(libvirt_domain_info_meta{job=\"libvirt_exporter\", instance_name=~\"$instance_name\"},uuid)",
-        "description": "Virtual Machine UUID from STFC Cloud OpenStack",
-        "hide": "dontHide",
-        "includeAll": false,
-        "label": "VM uuid",
-        "multi": false,
-        "name": "uuid",
-        "options": [],
-        "query": {
-          "datasource": {
-            "name": "remote_write_prometheus"
-          },
-          "group": "prometheus",
-          "kind": "DataQuery",
-          "spec": {
-            "qryType": 1,
-            "query": "label_values(libvirt_domain_info_meta{job=\"libvirt_exporter\", instance_name=~\"$instance_name\"},uuid)",
-            "refId": "PrometheusVariableQueryEditor-VariableQuery"
-          },
-          "version": "v0"
-        },
-        "refresh": "onDashboardLoad",
-        "regex": "",
-        "regexApplyTo": "value",
-        "skipUrlSync": false,
-        "sort": "disabled"
-      }
-    },
-    {
-      "kind": "QueryVariable",
-      "spec": {
-        "allowCustomValue": true,
-        "current": {
-          "text": "hv-a100x8-6.nubes.rl.ac.uk",
-          "value": "hv-a100x8-6.nubes.rl.ac.uk"
-        },
-        "definition": "label_values(libvirt_domain_info_meta{job=\"libvirt_exporter\", uuid=~\"$uuid\"},instance)",
-        "hide": "dontHide",
-        "includeAll": false,
-        "label": "Hypervisor",
-        "multi": false,
-        "name": "Hypervisor",
-        "options": [],
-        "query": {
-          "datasource": {
-            "name": "remote_write_prometheus"
-          },
-          "group": "prometheus",
-          "kind": "DataQuery",
-          "spec": {
-            "qryType": 1,
-            "query": "label_values(libvirt_domain_info_meta{job=\"libvirt_exporter\", uuid=~\"$uuid\"},instance)",
-            "refId": "PrometheusVariableQueryEditor-VariableQuery"
-          },
-          "version": "v0"
-        },
-        "refresh": "onDashboardLoad",
-        "regex": "",
-        "regexApplyTo": "value",
-        "skipUrlSync": false,
-        "sort": "alphabeticalAsc"
-      }
-    },
-    {
-      "kind": "QueryVariable",
-      "spec": {
-        "allowCustomValue": false,
-        "current": {
-          "text": "All",
-          "value": "$__all"
-        },
-        "definition": "label_values(libvirt_domain_info_meta{job=\"libvirt_exporter\", instance_name=~\"$instance_name\"},domain)",
-        "hide": "dontHide",
-        "includeAll": true,
-        "label": "Domain",
-        "multi": false,
-        "name": "domain",
-        "options": [],
-        "query": {
-          "datasource": {
-            "name": "remote_write_prometheus"
-          },
-          "group": "prometheus",
-          "kind": "DataQuery",
-          "spec": {
-            "qryType": 1,
-            "query": "label_values(libvirt_domain_info_meta{job=\"libvirt_exporter\", instance_name=~\"$instance_name\"},domain)",
-            "refId": "PrometheusVariableQueryEditor-VariableQuery"
-          },
-          "version": "v0"
-        },
-        "refresh": "onDashboardLoad",
-        "regex": "",
-        "regexApplyTo": "value",
-        "skipUrlSync": false,
-        "sort": "disabled"
-      }
-    },
-    {
-      "kind": "ConstantVariable",
-      "spec": {
-        "current": {
-          "text": "126",
-          "value": "126"
-        },
-        "description": "",
-        "hide": "hideVariable",
-        "label": "",
-        "name": "carbon_intensity",
-        "query": "126",
-        "skipUrlSync": true
-      }
-    },
-    {
-      "kind": "ConstantVariable",
-      "spec": {
-        "current": {
-          "text": "1.3",
-          "value": "1.3"
-        },
-        "hide": "hideVariable",
-        "name": "pue",
-        "query": "1.3",
-        "skipUrlSync": true
-      }
-    }
-  ]
+  "version": 1,
+  "uid": "vm_power_and_carbon_method_2",
+  "id": 2323835492880384
 }


### PR DESCRIPTION
### Description:

Our dashboards are being provisioned with the v1 API. These dashboards won't load as they require the v2 API. Reverting these back to v1 so we can get them displayed. Future work will be needed to update everything to v2.

---

### Reviewer:

As part of reviewing this PR the changes must be tested on a Grafana instance. To do this:

* [x] SSH into the dev-grafana instance. `ssh ubuntu@dev-grafana.nubes.rl.ac.uk`
      
* [x] As Root change the git branch the dashboard folder (`/etc/grafana/provisioning/dashboards`) using: `git switch <branch-name>`
  
* [x] Restart the Grafana service: `systemctl restart grafana-server`

Have you:

* [ ] Checked whether the panels are clear and easy to read?

* [ ] Changed the branch back to main once the branch is merged
